### PR TITLE
Correct the latest restart index from events

### DIFF
--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -132,10 +132,11 @@ class Tracker(object):
 
         If the conversation has not been restarted, ``0`` is returned."""
 
-        for i, event in enumerate(reversed(self.events)):
-            if event.get("name") == "action_restart":
-                return len(self.events) - i
-        return 0
+        idx = 0
+        for i, event in enumerate(self.events):
+            if event.get("event") == "restarted":
+                idx = i + 1
+        return idx
 
     def events_after_latest_restart(self):
         # type: () -> List[dict]

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -133,7 +133,7 @@ class Tracker(object):
         If the conversation has not been restarted, ``0`` is returned."""
 
         for i, event in enumerate(reversed(self.events)):
-            if event.get("name") == "restart":
+            if event.get("event") == "restart":
                 return len(self.events) - i
         return 0
 

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -132,11 +132,10 @@ class Tracker(object):
 
         If the conversation has not been restarted, ``0`` is returned."""
 
-        idx = 0
-        for i, event in enumerate(self.events):
-            if event.get("event") == "restarted":
-                idx = i + 1
-        return idx
+        for i, event in enumerate(reversed(self.events)):
+            if event.get("name") == "action_restart":
+                return len(self.events) - i
+        return 0
 
     def events_after_latest_restart(self):
         # type: () -> List[dict]

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -134,7 +134,7 @@ class Tracker(object):
 
         idx = 0
         for i, event in enumerate(self.events):
-            if event.get("event") == "restarted":
+            if event.get("event") == "restart":
                 idx = i + 1
         return idx
 

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -133,7 +133,7 @@ class Tracker(object):
         If the conversation has not been restarted, ``0`` is returned."""
 
         for i, event in enumerate(reversed(self.events)):
-            if event.get("event") == "restart":
+            if event.get("name") == "restart":
                 return len(self.events) - i
         return 0
 

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -133,7 +133,7 @@ class Tracker(object):
         If the conversation has not been restarted, ``0`` is returned."""
 
         for i, event in enumerate(reversed(self.events)):
-            if event.get("name") == "action_restart":
+            if event.get("name") == "restart":
                 return len(self.events) - i
         return 0
 

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -133,7 +133,7 @@ class Tracker(object):
         If the conversation has not been restarted, ``0`` is returned."""
 
         for i, event in enumerate(reversed(self.events)):
-            if event.get("name") == "restart":
+            if event.get("name") == "action_restart":
                 return len(self.events) - i
         return 0
 


### PR DESCRIPTION
**Proposed changes**:
- The current `tracker` checks for a restart event by comparing against `restarted`, change it to ~~`action_restart`~~ `restart`

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
