### PR TITLE
Remove validation in form run

### DIFF
--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -526,8 +526,6 @@ class FormAction(Action):
 
         # activate the form
         events = self._activate_if_required(dispatcher, tracker, domain)
-        # validate user input
-        events.extend(self._validate_if_required(dispatcher, tracker, domain))
         # check that the form wasn't deactivated in validation
         if Form(None) not in events:
 


### PR DESCRIPTION
The same slots are validated in form activation which causes the slot validation to run twice. This can cause duplicant utterances to the user if they are dispatched in custom validate_{slotname} functions.

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
