### PR TITLE
add utter_image_url

### DIFF
--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -116,6 +116,14 @@ class CollectingDispatcher(object):
 
         self.messages.append(json_message)
 
+    def utter_image_url(self, image, **kwargs):
+        """ sends image url to the output channel as image"""
+
+        json_message = {"image": image}
+        json_message.update(kwargs)
+
+        self.messages.append(json_message)
+
 
 class ActionExecutor(object):
     def __init__(self):

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -116,11 +116,8 @@ class CollectingDispatcher(object):
 
         self.messages.append(json_message)
 
-    def utter_image_url(self,
-                        image, # type : Text
-                        **kwargs # type : Any
-    ):
-
+    def utter_image_url(self, image, **kwargs):
+        # type: (Text, Any) -> None
         """Sends url of image attachment to the output channel."""
 
         message = {"image": image}

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -116,13 +116,17 @@ class CollectingDispatcher(object):
 
         self.messages.append(json_message)
 
-    def utter_image_url(self, image, **kwargs):
-        """ sends image url to the output channel as image"""
+    def utter_image_url(self,
+                        image, # type : Text
+                        **kwargs # type : Any
+    ):
 
-        json_message = {"image": image}
-        json_message.update(kwargs)
+        """Sends url of image attachment to the output channel."""
 
-        self.messages.append(json_message)
+        message = {"image": image}
+        message.update(kwargs)
+
+        self.messages.append(message)
 
 
 class ActionExecutor(object):


### PR DESCRIPTION
**Proposed changes**:
- When trying to send image from custom actions there is no function in the dispatcher to send image as a URL. But in rasa core, it supports the image sending and only needs to send image url formated as {"image" : image_url }. Added utter_image_url function and implementation to CollectingDispatcher class. 

**Status (please check what you already did)**:
- [+] made PR ready for code review
- [- ] added some tests for the functionality
- [- ] updated the documentation
- [- ] updated the changelog
