### PR TITLE
prevent non-vital commands from running as root

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,7 @@ Changed
 
 Fixed
 -----
-- ``rasa-sdk`` containers will now not run as root
+- ``rasa-sdk`` containers will now not run as ``root``
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changed
 
 Fixed
 -----
+- ``rasa-sdk`` containers will now not run as root
 
 Removed
 -------

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ COPY . .
 
 RUN pip install -e . --no-cache-dir
 
+RUN groupadd -g 1000 nonroot && \
+  useradd -r -u 1000 -g nonroot nonroot
+USER nonroot
+
 VOLUME ["/app/actions"]
 
 EXPOSE 5055

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY . .
 RUN pip install -e . --no-cache-dir
 
 RUN groupadd -g 1000 nonroot && \
-  useradd -r -u 1000 -g nonroot nonroot
+  useradd -r -u 1001 -g nonroot nonroot
 USER nonroot
 
 VOLUME ["/app/actions"]


### PR DESCRIPTION
**Proposed changes**:
- prevent `rasa-sdk` containers from running as root, using [this pattern](https://medium.com/@mccode/processes-in-containers-should-not-run-as-root-2feae3f0df3b)
> fixes #114 

> Note: image file increased by only 1 MB after proposed change:
> ```sh
> REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
> test                1.0                 f97cbb6f4eb7        21 minutes ago      423MB
> rasa/rasa-sdk       1.4.0               aac88e91443f        3 weeks ago         422MB
> ```

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the changelog
