### PR TITLE
change deprecated `utter_template` calls to `utter_message`

### DIFF
--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -374,11 +374,8 @@ class FormAction(Action):
         for slot in self.required_slots(tracker):
             if self._should_request_slot(tracker, slot):
                 logger.debug("Request next slot '{}'".format(slot))
-                dispatcher.utter_template(
-                    "utter_ask_{}".format(slot),
-                    tracker,
-                    silent_fail=False,
-                    **tracker.slots,
+                dispatcher.utter_message(
+                    template="utter_ask_{}".format(slot), **tracker.slots
                 )
                 return [SlotSet(REQUESTED_SLOT, slot)]
 

--- a/rasa_sdk/knowledge_base/actions.py
+++ b/rasa_sdk/knowledge_base/actions.py
@@ -128,7 +128,7 @@ class ActionQueryKnowledgeBase(Action):
         if not object_type:
             # object type always needs to be set as this is needed to query the
             # knowledge base
-            dispatcher.utter_template("utter_ask_rephrase", tracker)
+            dispatcher.utter_message(template="utter_ask_rephrase")
             return []
 
         if not attribute or new_request:
@@ -136,7 +136,7 @@ class ActionQueryKnowledgeBase(Action):
         elif attribute:
             return self._query_attribute(dispatcher, tracker)
 
-        dispatcher.utter_template("utter_ask_rephrase", tracker)
+        dispatcher.utter_message(template="utter_ask_rephrase")
         return []
 
     def _query_objects(
@@ -207,13 +207,13 @@ class ActionQueryKnowledgeBase(Action):
         )
 
         if not object_name or not attribute:
-            dispatcher.utter_template("utter_ask_rephrase", tracker)
+            dispatcher.utter_message(template="utter_ask_rephrase")
             return [SlotSet(SLOT_MENTION, None)]
 
         object_of_interest = self.knowledge_base.get_object(object_type, object_name)
 
         if not object_of_interest or attribute not in object_of_interest:
-            dispatcher.utter_template("utter_ask_rephrase", tracker)
+            dispatcher.utter_message(template="utter_ask_rephrase")
             return [SlotSet(SLOT_MENTION, None)]
 
         value = object_of_interest[attribute]


### PR DESCRIPTION
**Proposed changes**:
- change deprecated `utter_template` calls to `utter_message`

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
