### PR TITLE
implement additional tracker methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,11 @@ Bugfixes
 --------
 - Pinned ``sanic~=19.9.0`` to fix breaking changes introduced in sanic 19.9.12.
 
+Added
+-----
+- Copied over instance methods `last_executed_action_has`, `get_last_event_for` and
+  `applied_events` from the Rasa Tracker class to the SDK Tracker class.
+
 [1.6.0] - 2019-12-18
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,15 +12,6 @@ This project adheres to `Semantic Versioning`_ starting with version 0.11.0.
     https://github.com/RasaHQ/rasa-sdk/tree/master/changelog/ .
 .. towncrier release notes start
 
-[PR] - 2020-02-23
-^^^^^^^^^^^^^^^^^^^^
-
-Added
------
-- Copied over instance methods ``last_executed_action_has()``, ``get_last_event_for()`` and
-  ``applied_events`` from the Rasa ``DialogueStateTracker`` class to the SDK ``Tracker`` class.
-
-
 [1.7.0] - 2020-01-29
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ This project adheres to `Semantic Versioning`_ starting with version 0.11.0.
     https://github.com/RasaHQ/rasa-sdk/tree/master/changelog/ .
 .. towncrier release notes start
 
+[PR] - 2020-02-23
+^^^^^^^^^^^^^^^^^^^^
+
+Added
+-----
+- Copied over instance methods ``last_executed_action_has()``, ``get_last_event_for()`` and
+  ``applied_events`` from the Rasa ``DialogueStateTracker`` class to the SDK ``Tracker`` class.
+
+
 [1.7.0] - 2020-01-29
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -42,10 +51,6 @@ Bugfixes
 --------
 - Pinned ``sanic~=19.9.0`` to fix breaking changes introduced in sanic 19.9.12.
 
-Added
------
-- Copied over instance methods `last_executed_action_has`, `get_last_event_for` and
-  `applied_events` from the Rasa Tracker class to the SDK Tracker class.
 
 [1.6.0] - 2019-12-18
 ^^^^^^^^^^^^^^^^^^^^

--- a/changelog/130.improvement.rst
+++ b/changelog/130.improvement.rst
@@ -1,0 +1,2 @@
+Copied over instance methods ``last_executed_action_has()``, ``get_last_event_for()`` and
+  ``applied_events`` from the Rasa ``DialogueStateTracker`` class to the SDK ``Tracker`` class.

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -157,7 +157,7 @@ class Tracker:
 
     def get_last_event_for(
         self, event_type: Text, exclude: List[Text] = [], skip: int = 0
-    ) -> Dict[Text, Any]:
+    ) -> Optional[Dict[Text, Any]]:
         def filter_function(e: Dict[Text, Any]) -> bool:
             has_instance = e["event"] == event_type
             excluded = e["event"] == "action" and e["name"] in exclude

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -149,14 +149,16 @@ class Tracker:
             self.latest_action_name,
         )
 
-    def last_executed_action_has(self, name, skip=0):
+    def last_executed_action_has(self, name: Text, skip: int = 0) -> bool:
         last = self.get_last_event_for(
             "action", exclude=[ACTION_LISTEN_NAME], skip=skip
         )
         return last is not None and last["name"] == name
 
-    def get_last_event_for(self, event_type, exclude=[], skip=0):
-        def filter_function(e: Dict):
+    def get_last_event_for(
+        self, event_type: Text, exclude: List[Text] = [], skip: int = 0
+    ) -> Dict[Text, Any]:
+        def filter_function(e: Dict[Text, Any]) -> bool:
             has_instance = e["event"] == event_type
             excluded = e["event"] == "action" and e["name"] in exclude
 
@@ -168,10 +170,10 @@ class Tracker:
 
         return next(filtered, None)
 
-    def applied_events(self) -> List[Dict]:
+    def applied_events(self) -> List[Dict[Text, Any]]:
         """Returns all actions that should be applied - w/o reverted events."""
 
-        def undo_till_previous(event_type, done_events):
+        def undo_till_previous(event_type: Text, done_events: List[Dict[Text, Any]]):
             """Removes events from `done_events` until the first
                 occurrence `event_type` is found which is also removed."""
             # list gets modified - hence we need to copy events!
@@ -182,11 +184,11 @@ class Tracker:
 
         applied_events = []
         for event in self.events:
-            if event.get("name", None) == "restart":
+            if event.get("name") == "restart":
                 applied_events = []
-            elif event.get("name", None) == "undo":
+            elif event.get("name") == "undo":
                 undo_till_previous("action", applied_events)
-            elif event.get("name", None) == "rewind":
+            elif event.get("name") == "rewind":
                 # Seeing a user uttered event automatically implies there was
                 # a listen event right before it, so we'll first rewind the
                 # user utterance, then get the action right before it (also removes

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,20 +1,72 @@
 from rasa_sdk import Tracker
-from rasa_sdk.events import ActionExecuted, UserUttered
+from rasa_sdk.events import ActionExecuted, UserUttered, ActionReverted
+from rasa_sdk.interfaces import ACTION_LISTEN_NAME
+from typing import List, Dict, Text, Any
+
+
+def user_uttered(text: Text, confidence: float) -> UserUttered:
+    parse_data = {"intent": {"name": text, "confidence": confidence}}
+    return UserUttered(text="Random", parse_data=parse_data)
+
+
+def get_tracker(events: List[Dict[Text, Any]]) -> Tracker:
+    return Tracker.from_dict({"sender_id": "sender", "events": events})
 
 
 def test_latest_input_channel():
-    tracker = Tracker(
-        "default",
-        {},
-        {"intent": {"name": "some_intent", "confidence": 1.0}},
+    tracker = get_tracker(
         [
             UserUttered("my message text", input_channel="superchat"),
             ActionExecuted("action_listen"),
-        ],
-        False,
-        None,
-        {},
-        "action_listen",
+        ]
     )
 
     assert tracker.get_latest_input_channel() == "superchat"
+
+
+def test_get_last_event_for():
+    events = [ActionExecuted("one"), user_uttered("two", 1)]
+
+    tracker = get_tracker(events)
+
+    assert tracker.get_last_event_for("action").get("name") == "one"
+
+
+def test_get_last_event_for_with_skip():
+    events = [ActionExecuted("one"), user_uttered("two", 1), ActionExecuted("three")]
+
+    tracker = get_tracker(events)
+
+    assert tracker.get_last_event_for("action", skip=1).get("name") == "one"
+
+
+def test_get_last_event_for_with_exclude():
+    events = [ActionExecuted("one"), user_uttered("two", 1), ActionExecuted("three")]
+
+    tracker = get_tracker(events)
+
+    assert tracker.get_last_event_for("action", exclude=["three"]).get("name") == "one"
+
+
+def test_last_executed_has():
+    events = [
+        ActionExecuted("one"),
+        user_uttered("two", 1),
+        ActionExecuted(ACTION_LISTEN_NAME),
+    ]
+
+    tracker = get_tracker(events)
+
+    assert tracker.last_executed_action_has("one") is True
+
+
+def test_last_executed_has_not_name():
+    events = [
+        ActionExecuted("one"),
+        user_uttered("two", 1),
+        ActionExecuted(ACTION_LISTEN_NAME),
+    ]
+
+    tracker = get_tracker(events)
+
+    assert tracker.last_executed_action_has("another") is False


### PR DESCRIPTION
**Proposed changes**:
The Rasa tracker class implements the convenience methods `last_executed_action_has`, `get_last_event_for` and `applied_events`. This PR simply copies over this functionality from Rasa.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
