### PR TITLE
Server should not start if module not found

### DIFF
--- a/changelog/110.bugfix.rst
+++ b/changelog/110.bugfix.rst
@@ -1,0 +1,4 @@
+Exit program (``python -m rasa_sdk --actions actions`` or
+``rasa run actions --actions actions``) if a requested module under the
+``--actions`` command-line option cannot be found.
+

--- a/changelog/110.bugfix.rst
+++ b/changelog/110.bugfix.rst
@@ -1,4 +1,3 @@
 Exit program (``python -m rasa_sdk --actions actions`` or
 ``rasa run actions --actions actions``) if a requested module under the
 ``--actions`` command-line option cannot be found.
-

--- a/changelog/153.bugfix.rst
+++ b/changelog/153.bugfix.rst
@@ -1,1 +1,1 @@
-Make it possible to use the ``requests`` library inside the default Rasa SDK container.
+Adding sys.exit(1) right after Import Error in register_package().

--- a/changelog/153.bugfix.rst
+++ b/changelog/153.bugfix.rst
@@ -1,1 +1,1 @@
-Adding sys.exit(1) right after Import Error in register_package().
+Adding sys.exit(1) right after Import Error in register_package() in executer.py

--- a/changelog/153.bugfix.rst
+++ b/changelog/153.bugfix.rst
@@ -1,3 +1,1 @@
-Exit program (``python -m rasa_sdk --actions actions`` or 
-``rasa run actions --actions actions``) if a requested module under the 
-``--actions`` command-line option cannot be found.
+Make it possible to use the ``requests`` library inside the default Rasa SDK container.

--- a/changelog/153.bugfix.rst
+++ b/changelog/153.bugfix.rst
@@ -1,3 +1,4 @@
 Exit program (``python -m rasa_sdk --actions actions`` or 
 ``rasa run actions --actions actions``) if a requested module under the 
-``--actions`` command-line option cannot be found. 
+``--actions`` command-line option cannot be found,
+by adding sys.exit(1) after Import Error in in register_package() function in executer.py

--- a/changelog/153.bugfix.rst
+++ b/changelog/153.bugfix.rst
@@ -1,4 +1,3 @@
 Exit program (``python -m rasa_sdk --actions actions`` or 
 ``rasa run actions --actions actions``) if a requested module under the 
-``--actions`` command-line option cannot be found,
-by adding sys.exit(1) after Import Error in in register_package() function in executer.py
+``--actions`` command-line option cannot be found.

--- a/changelog/153.bugfix.rst
+++ b/changelog/153.bugfix.rst
@@ -1,1 +1,3 @@
-Adding sys.exit(1) right after Import Error in register_package() in executer.py
+Exit program (``python -m rasa_sdk --actions actions`` or 
+``rasa run actions --actions actions``) if a requested module under the 
+``--actions`` command-line option cannot be found. 

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -6,6 +6,7 @@ import warnings
 from typing import Text, List, Dict, Any, Type, Union, Callable, Optional
 import typing
 import types
+import sys
 
 from rasa_sdk.interfaces import Tracker, ActionNotFoundException
 

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -188,7 +188,15 @@ class ActionExecutor:
         :rtype: dict[str, types.ModuleType]
         """
         if isinstance(package, str):
-            package = importlib.import_module(package)
+            if package=="actions":
+                try:
+                    package = importlib.import_module(package)
+                except ImportError:
+                    print("Could not find a module `actions`. Did you provide the correct path to the actions file or folder via the '--actions' parameter?")
+                    exit()
+            else:
+                package = importlib.import_module(package)
+
         if not getattr(package, "__path__", None):
             return
 

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -192,7 +192,7 @@ class ActionExecutor:
                 try:
                     package = importlib.import_module(package)
                 except ImportError:
-                    logger.exception(f"Could not import actions. Actions not found.")
+                    logger.exception(f"Could not import actions. Actions not found")
                     exit()
             else:
                 package = importlib.import_module(package)

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -192,7 +192,7 @@ class ActionExecutor:
                 try:
                     package = importlib.import_module(package)
                 except ImportError:
-                    logger.exception(f"Could not import actions. Actions not found")
+                    logger.exception(f"Could not import actions.")
                     exit(1)
             else:
                 package = importlib.import_module(package)

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -207,7 +207,7 @@ class ActionExecutor:
             self._import_submodules(package)
         except ImportError:
             logger.exception(f"Failed to register package '{package}'.")
-            exit(1)
+            sys.exit(1)
 
         actions = utils.all_subclasses(Action)
 

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -196,6 +196,8 @@ class ActionExecutor:
                     exit()
             else:
                 package = importlib.import_module(package)
+                if type(package) == str:
+                    exit()
 
         if not getattr(package, "__path__", None):
             return

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -197,7 +197,7 @@ class ActionExecutor:
             else:
                 package = importlib.import_module(package)
                 if type(package) == str:
-                    exit()
+                    exit(1)
 
         if not getattr(package, "__path__", None):
             return

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -193,7 +193,7 @@ class ActionExecutor:
                     package = importlib.import_module(package)
                 except ImportError:
                     logger.exception(f"Could not import actions. Actions not found")
-                    exit()
+                    exit(1)
             else:
                 package = importlib.import_module(package)
                 if type(package) == str:

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -188,11 +188,11 @@ class ActionExecutor:
         :rtype: dict[str, types.ModuleType]
         """
         if isinstance(package, str):
-            if package=="actions":
+            if package == "actions":
                 try:
                     package = importlib.import_module(package)
                 except ImportError:
-                    print("Could not find a module `actions`. Did you provide the correct path to the actions file or folder via the '--actions' parameter?")
+                    logger.exception(f"Could not import actions. Actions not found.")
                     exit()
             else:
                 package = importlib.import_module(package)

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -188,16 +188,7 @@ class ActionExecutor:
         :rtype: dict[str, types.ModuleType]
         """
         if isinstance(package, str):
-            if package == "actions":
-                try:
-                    package = importlib.import_module(package)
-                except ImportError:
-                    logger.exception(f"Could not import actions.")
-                    exit(1)
-            else:
-                package = importlib.import_module(package)
-                if type(package) == str:
-                    exit(1)
+            package = importlib.import_module(package)
 
         if not getattr(package, "__path__", None):
             return
@@ -216,6 +207,7 @@ class ActionExecutor:
             self._import_submodules(package)
         except ImportError:
             logger.exception(f"Failed to register package '{package}'.")
+            exit(1)
 
         actions = utils.all_subclasses(Action)
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -7,9 +7,11 @@ from rasa_sdk.events import SlotSet
 # noinspection PyTypeChecker
 app = ep.create_app(None)
 
+
 def test_endpoint_exit_for_unknown_actions_package():
     with pytest.raises(SystemExit):
         ep.create_app("non-existing-actions-package")
+
 
 def test_server_health_returns_200():
     request, response = app.test_client.get("/health")

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -4,8 +4,12 @@ import json
 import rasa_sdk.endpoint as ep
 from rasa_sdk.events import SlotSet
 
-app = ep.create_app("actions.act")
+# noinspection PyTypeChecker
+app = ep.create_app(None)
 
+def test_endpoint_exit_for_unknown_actions_package():
+    with pytest.raises(SystemExit):
+        ep.create_app("non-existing-actions-package")
 
 def test_server_health_returns_200():
     request, response = app.test_client.get("/health")


### PR DESCRIPTION
**Issue**:
In cases, when the actions.py or the actions directory is missing, rasa throws ImportError excption but does not terminate the process and the action keeps running, as metioned #110 

**Proposed changes**:
Adding sys.exit(1) right after Import Error in register_package().

**Status**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)

