### PR TITLE
Add auto-reload upon file timestamp change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ examples/moodbot/models/
 .dir-locals.el
 
 *.DS_Store
+tests/executor_test_packages

--- a/changelog/164.feature.rst
+++ b/changelog/164.feature.rst
@@ -1,0 +1,4 @@
+Added new ``--auto-reload`` CLI argument. When specified, modules containing ``Action``
+subclasses will be automatically reloaded if they have been modified since the last HTTP
+request. By using this, one can avoid having to re-start the actions server when
+developing new actions.

--- a/rasa_sdk/__main__.py
+++ b/rasa_sdk/__main__.py
@@ -18,6 +18,7 @@ def main_from_args(args):
         args.ssl_certificate,
         args.ssl_keyfile,
         args.ssl_password,
+        args.auto_reload,
     )
 
 

--- a/rasa_sdk/cli/arguments.py
+++ b/rasa_sdk/cli/arguments.py
@@ -49,3 +49,8 @@ def add_endpoint_arguments(parser):
         help="If your ssl-keyfile is protected by a password, you can specify it "
         "using this paramer.",
     )
+    parser.add_argument(
+        "--auto-reload",
+        help="Enable auto-reloading of modules containing Action subclasses.",
+        action="store_true",
+    )

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 import types
-from typing import List, Text, Union, Optional, Any
+from typing import List, Text, Union, Optional, Any, NoReturn
 from ssl import SSLContext
 
 from sanic import Sanic, response

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -59,6 +59,7 @@ def create_argument_parser():
 def create_app(
     action_package_name: Union[Text, types.ModuleType],
     cors_origins: Union[Text, List[Text], None] = "*",
+    auto_reload: bool = False,
 ) -> Sanic:
     app = Sanic(__name__, configure_logging=False)
 
@@ -82,6 +83,10 @@ def create_app(
             return response.json(body, status=400)
 
         utils.check_version_compatibility(action_call.get("version"))
+
+        if auto_reload:
+            executor.reload()
+
         try:
             result = await executor.run(action_call)
         except ActionExecutionRejection as e:
@@ -98,6 +103,9 @@ def create_app(
     @app.get("/actions")
     async def actions(_) -> HTTPResponse:
         """List all registered actions."""
+        if auto_reload:
+            executor.reload()
+
         body = [{"name": k} for k in executor.actions.keys()]
         return response.json(body, status=200)
 
@@ -111,9 +119,12 @@ def run(
     ssl_certificate: Optional[Text] = None,
     ssl_keyfile: Optional[Text] = None,
     ssl_password: Optional[Text] = None,
+    auto_reload: bool = False,
 ):
     logger.info("Starting action endpoint server...")
-    app = create_app(action_package_name, cors_origins=cors_origins)
+    app = create_app(
+        action_package_name, cors_origins=cors_origins, auto_reload=auto_reload
+    )
     ssl_context = create_ssl_context(ssl_certificate, ssl_keyfile, ssl_password)
 
     app.run("0.0.0.0", port, ssl=ssl_context, workers=utils.number_of_sanic_workers())

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 import types
-from typing import List, Text, Union, Optional, Any, NoReturn
+from typing import List, Text, Union, Optional, Any
 from ssl import SSLContext
 
 from sanic import Sanic, response
@@ -131,7 +131,7 @@ def run(
     ssl_keyfile: Optional[Text] = None,
     ssl_password: Optional[Text] = None,
     auto_reload: bool = False,
-) -> NoReturn:
+) -> None:
     logger.info("Starting action endpoint server...")
     app = create_app(
         action_package_name, cors_origins=cors_origins, auto_reload=auto_reload

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -131,7 +131,7 @@ def run(
     ssl_keyfile: Optional[Text] = None,
     ssl_password: Optional[Text] = None,
     auto_reload: bool = False,
-):
+) -> NoReturn:
     logger.info("Starting action endpoint server...")
     app = create_app(
         action_package_name, cors_origins=cors_origins, auto_reload=auto_reload

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -61,6 +61,17 @@ def create_app(
     cors_origins: Union[Text, List[Text], None] = "*",
     auto_reload: bool = False,
 ) -> Sanic:
+    """Create a Sanic application and return it.
+
+    Args:
+        action_package_name: Name of the package or module to load actions
+            from.
+        cors_origins: CORS origins to allow.
+        auto_reload: When `True`, auto-reloading of actions is enabled.
+
+    Returns:
+        A new Sanic application ready to be run.
+    """
     app = Sanic(__name__, configure_logging=False)
 
     configure_cors(app, cors_origins)

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -224,12 +224,13 @@ class ActionExecutor:
         """
         module = importlib.import_module(name)
 
-        if module.__file__:
+        module_file = getattr(module, "__file__", None)
+        if module_file:
             # If the module we're importing is a namespace package (a package
             # without __init__.py), then there's nothing to watch for the
             # package itself.
-            timestamp = os.path.getmtime(module.__file__)
-            self._modules[module.__file__] = (timestamp, module)
+            timestamp = os.path.getmtime(module_file)
+            self._modules[module_file] = (timestamp, module)
 
         return module
 

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -144,6 +144,7 @@ class CollectingDispatcher:
 
 TimestampModule = namedtuple("TimestampModule", ["timestamp", "module"])
 
+
 class ActionExecutor:
     def __init__(self):
         self.actions = {}

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,4 +13,4 @@ license_file = LICENSE.txt
 
 [flake8]
 max-line-length = 88
-ignore = W503, E121, E126, E211, E225, E501, E203, E402, F401, F811, F821
+ignore = W503, E121, E126, E211, E225, E501, E203, E402, F401, F811

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -2,12 +2,11 @@ from typing import List, Dict, Text, Any
 
 from rasa_sdk import Action, Tracker
 from rasa_sdk.events import SlotSet
-from rasa_sdk.executor import ActionExecutor, CollectingDispatcher
+from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.utils import is_coroutine_action
 
 
 class CustomAsyncAction(Action):
-    @classmethod
     def name(cls) -> Text:
         return "custom_async_action"
 
@@ -20,30 +19,7 @@ class CustomAsyncAction(Action):
         return [SlotSet("test", "foo"), SlotSet("test2", "boo")]
 
 
-class CustomActionBase(Action):
-    @classmethod
-    def name(cls) -> Text:
-        # Name method needed to test if base action was registered
-        return "base_action"
-
-    class Meta:
-        abstract = True
-
-    @staticmethod
-    def some_common_feature() -> Text:
-        return "test"
-
-    def run(
-        self,
-        dispatcher: CollectingDispatcher,
-        tracker: Tracker,
-        domain: Dict[Text, Any],
-    ) -> List[Dict[Text, Any]]:
-        raise NotImplementedError
-
-
-class CustomAction(CustomActionBase):
-    @classmethod
+class CustomAction(Action):
     def name(cls) -> Text:
         return "custom_action"
 
@@ -53,23 +29,7 @@ class CustomAction(CustomActionBase):
         tracker: Tracker,
         domain: Dict[Text, Any],
     ) -> List[Dict[Text, Any]]:
-        return [SlotSet("test", self.some_common_feature())]
-
-
-def test_action_registration():
-    executor = ActionExecutor()
-    executor.register_package("tests")
-    assert CustomAction.name() in executor.actions
-    assert CustomActionBase.name() not in executor.actions
-
-
-def test_abstract_action():
-    dispatcher = CollectingDispatcher()
-    tracker = Tracker("test", {}, {}, [], False, None, {}, "listen")
-    domain = {}
-
-    events = CustomAction().run(dispatcher, tracker, domain)
-    assert events == [SlotSet("test", "test")]
+        return [SlotSet("test", "bar")]
 
 
 def test_action_async_check():

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -42,7 +42,7 @@ def test_server_webhook_custom_action_returns_200():
     request, response = app.test_client.post("/webhook", data=json.dumps(data))
     events = response.json.get("events")
 
-    assert events == [SlotSet("test", "test")]
+    assert events == [SlotSet("test", "bar")]
     assert response.status == 200
 
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -3,7 +3,7 @@ import shutil
 import random
 import string
 import time
-from typing import Text
+from typing import Text, Optional, Generator
 
 import pytest
 from rasa_sdk.executor import ActionExecutor, CollectingDispatcher
@@ -28,7 +28,7 @@ def _write_action_file(
     file_name: Text,
     class_name: Text,
     action_name: Text,
-    message: Text = None,
+    message: Optional[Text] = None,
 ) -> None:
     with open(os.path.join(package_path, file_name), "w") as f:
         f.write(
@@ -68,7 +68,7 @@ def test_deprecated_utter_elements():
 
 
 @pytest.fixture()
-def package_path() -> None:
+def package_path() -> Generator[Text, None, Text]:
     # Create an empty directory somewhere reached by the Python import search
     # paths
     name = "".join(random.choice(string.ascii_lowercase) for _ in range(10))

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,6 +1,41 @@
-import pytest
+import os
+import shutil
+import random
+import string
+import time
+from typing import Text
 
+import pytest
 from rasa_sdk.executor import ActionExecutor, CollectingDispatcher
+
+TEST_PACKAGE_BASE = "tests/executor_test_packages"
+
+ACTION_TEMPLATE = """
+from rasa_sdk import Action
+
+class {class_name}(Action):
+    def name(self):
+        return "{action_name}"
+
+    async def run(self, dispatcher, tracker, domain):
+        dispatcher.utter_message("{message}")
+        return []
+"""
+
+
+def _write_action_file(
+    package_path: Text,
+    file_name: Text,
+    class_name: Text,
+    action_name: Text,
+    message: Text = None,
+) -> None:
+    with open(os.path.join(package_path, file_name), "w") as f:
+        f.write(
+            ACTION_TEMPLATE.format(
+                class_name=class_name, action_name=action_name, message=message
+            )
+        )
 
 
 @pytest.mark.parametrize(
@@ -25,6 +60,138 @@ def test_deprecated_utter_elements():
         "text": None,
         "buttons": [],
         "elements": [1, 2, 3],
+        "custom": {},
+        "template": None,
+        "image": None,
+        "attachment": None,
+    }
+
+
+@pytest.fixture()
+def package_path() -> None:
+    # Create an empty directory somewhere reached by the Python import search
+    # paths
+    name = "".join(random.choice(string.ascii_lowercase) for _ in range(10))
+    package_path = os.path.join(TEST_PACKAGE_BASE, name)
+
+    # Ensure package dir is clean
+    shutil.rmtree(package_path, ignore_errors=True)
+    os.makedirs(package_path)
+    yield package_path
+
+    # Cleanup
+    shutil.rmtree(package_path, ignore_errors=True)
+
+
+@pytest.fixture()
+def executor() -> ActionExecutor:
+    return ActionExecutor()
+
+
+@pytest.fixture()
+def dispatcher() -> CollectingDispatcher:
+    return CollectingDispatcher()
+
+
+def test_load_action_from_init(executor: ActionExecutor, package_path: Text):
+    # Actions should be loaded from packages
+    _write_action_file(package_path, "__init__.py", "InitAction", "init_action")
+    executor.register_package(package_path.replace("/", "."))
+
+    assert "init_action" in executor.actions
+
+
+def test_load_submodules_in_package(executor: ActionExecutor, package_path: Text):
+    # If there's submodules inside a package, they should be picked up correctly
+    _write_action_file(package_path, "__init__.py", "Action1", "action1")
+    _write_action_file(package_path, "a1.py", "Action2", "action2")
+    _write_action_file(package_path, "a2.py", "Action3", "action3")
+
+    executor.register_package(package_path.replace("/", "."))
+
+    for name in ["action1", "action2", "action3"]:
+        assert name in executor.actions
+
+
+def test_load_submodules_in_namespace_package(
+    executor: ActionExecutor, package_path: Text
+):
+    # If there's submodules inside a namespace package (a package without
+    # __init__.py), they should be picked up correctly
+    _write_action_file(package_path, "foo.py", "FooAction", "foo_action")
+    _write_action_file(package_path, "bar.py", "BarAction", "bar_action")
+
+    executor.register_package(package_path.replace("/", "."))
+
+    for name in ["foo_action", "bar_action"]:
+        assert name in executor.actions
+
+
+def test_load_module_directly(executor: ActionExecutor, package_path: Text):
+    _write_action_file(
+        package_path, "test_module.py", "TestModuleAction", "test_module_action"
+    )
+
+    # Load a module directly, not a package. This is equivalent to loading
+    # "action" when there's an "action.py" file in the module search path.
+    executor.register_package(package_path.replace("/", ".") + ".test_module")
+
+    assert "test_module_action" in executor.actions
+
+
+async def test_reload_module(
+    executor: ActionExecutor, dispatcher: CollectingDispatcher, package_path: Text
+):
+    action_class = "MyAction"
+    action_file = "my_action.py"
+    action_name = "my_action"
+
+    _write_action_file(
+        package_path, action_file, action_class, action_name, message="foobar"
+    )
+
+    executor.register_package(package_path.replace("/", "."))
+
+    action_v1 = executor.actions.get(action_name)
+    assert action_v1
+
+    await action_v1(dispatcher, None, None)
+
+    assert dispatcher.messages[0] == {
+        "text": "foobar",
+        "buttons": [],
+        "elements": [],
+        "custom": {},
+        "template": None,
+        "image": None,
+        "attachment": None,
+    }
+
+    # Write the action file again, but change its contents
+    _write_action_file(
+        package_path, action_file, action_class, action_name, message="hello!"
+    )
+
+    # Manually set the file's timestamp 10 seconds into the future, otherwise
+    # Python will load the class already compiled in __pycache__, which is the
+    # previous version.
+    mod_time = time.time() + 10
+    os.utime(os.path.join(package_path, action_file), times=(mod_time, mod_time))
+
+    # Reload modules
+    executor.reload()
+    dispatcher.messages.clear()
+
+    action_v2 = executor.actions.get(action_name)
+    assert action_v2
+
+    await action_v2(dispatcher, None, None)
+
+    # The message should have changed
+    assert dispatcher.messages[0] == {
+        "text": "hello!",
+        "buttons": [],
+        "elements": [],
         "custom": {},
         "template": None,
         "image": None,


### PR DESCRIPTION
**Proposed changes**:
- Add a new CLI argument, `--auto-reload`. If enabled, modules containing actions will be reloaded when an HTTP request is received, but only if the files have been changed since they were last loaded.
- Closes https://github.com/RasaHQ/rasa/issues/4058.

Implementation details:

When we load a regular package (directory with `__init__.py` inside), or a file module (e.g. `actions.py`), the file path and last-modified timestamp is recorded. Whenever an HTTP request is received, before running the actions, all current file timestamps are checked against the recorded ones (there is no polling or file modification events involved). This process is quick because it only involves comparing floats. All files that have been modified since the last check are re-loaded using `importlib.reload`. After that, the whole `Action` class hierarchy is re-scanned, and the classes are registered.

One of the problems of re-loading modules is that the classes that have been already defined there aren't deleted or anything, so they are still part of the `Action` hierarchy. The consequence of this is that if a module containing `MyAction` is re-loaded, then there will be two `MyAction` classes in the hierarchy. To get around this, each time an action class is registered, it is "tagged" with `action_class._sdk_loaded = True`. That way, when we re-scan the `Action` class hierarchy, we know what actions we have already loaded in the past, and we can ignore them.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
