### PR TITLE
Use custom mapping "from_entity" to fill other slots

### DIFF
--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -189,7 +189,7 @@ class FormAction(Action):
 
         return intent_not_blacklisted or intent in mapping_intents
 
-    def slot_is_desired(
+    def entity_is_desired(
         self, requested_slot_mapping: Dict[Text, Any], slot: Text, tracker: "Tracker"
     ) -> bool:
         """Check whether slot should be filled or not."""
@@ -197,8 +197,8 @@ class FormAction(Action):
         # slot name is equal to the entity type
         slot_equal_entity = slot == requested_slot_mapping.get("entity")
 
-        # use the custom slot mapping defined by the user to fill a slot based on
-        # a role or group
+        # use the custom slot mapping defined by the user to check whether we can
+        # fil a slot with an entity that has a role or group set
         slot_fulfils_entity_mapping = False
         if requested_slot_mapping.get("role") or requested_slot_mapping.get("group"):
             matching_values = self.get_entity_value(
@@ -265,7 +265,7 @@ class FormAction(Action):
                     should_fill_entity_slot = (
                         other_slot_mapping["type"] == "from_entity"
                         and self.intent_is_desired(other_slot_mapping, tracker)
-                        and self.slot_is_desired(other_slot_mapping, slot, tracker)
+                        and self.entity_is_desired(other_slot_mapping, slot, tracker)
                     )
                     # check whether the slot should be
                     # filled from trigger intent mapping

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -197,17 +197,15 @@ class FormAction(Action):
         # slot name is equal to the entity type
         slot_equal_entity = slot == requested_slot_mapping.get("entity")
 
-        # use the custom slot mapping defined by the user to check whether we can
-        # fil a slot with an entity that has a role or group set
-        slot_fulfils_entity_mapping = False
-        if requested_slot_mapping.get("role") or requested_slot_mapping.get("group"):
-            matching_values = self.get_entity_value(
-                requested_slot_mapping.get("entity"),
-                tracker,
-                requested_slot_mapping.get("role"),
-                requested_slot_mapping.get("group"),
-            )
-            slot_fulfils_entity_mapping = matching_values is not None
+        # use the custom slot mapping 'from_entity' defined by the user to check
+        # whether we can fil a slot with an entity
+        matching_values = self.get_entity_value(
+            requested_slot_mapping.get("entity"),
+            tracker,
+            requested_slot_mapping.get("role"),
+            requested_slot_mapping.get("group"),
+        )
+        slot_fulfils_entity_mapping = matching_values is not None
 
         return slot_equal_entity or slot_fulfils_entity_mapping
 

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -198,7 +198,7 @@ class FormAction(Action):
         slot_equal_entity = slot == requested_slot_mapping.get("entity")
 
         # use the custom slot mapping 'from_entity' defined by the user to check
-        # whether we can fil a slot with an entity
+        # whether we can fill a slot with an entity
         matching_values = self.get_entity_value(
             requested_slot_mapping.get("entity"),
             tracker,

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -192,7 +192,7 @@ class FormAction(Action):
     def entity_is_desired(
         self, requested_slot_mapping: Dict[Text, Any], slot: Text, tracker: "Tracker"
     ) -> bool:
-        """Check whether slot should be filled or not."""
+        """Check whether slot should be filled by an entity in the input or not."""
 
         # slot name is equal to the entity type
         slot_equal_entity = slot == requested_slot_mapping.get("entity")
@@ -258,8 +258,7 @@ class FormAction(Action):
                 other_slot_mappings = self.get_mappings_for_slot(slot)
 
                 for other_slot_mapping in other_slot_mappings:
-                    # check whether the slot should be filled
-                    # by entity with the same name
+                    # check whether the slot should be filled by an entity in the input
                     should_fill_entity_slot = (
                         other_slot_mapping["type"] == "from_entity"
                         and self.intent_is_desired(other_slot_mapping, tracker)

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -259,10 +259,6 @@ class FormAction(Action):
                 # list is used to cover the case of list slot type
                 other_slot_mappings = self.get_mappings_for_slot(slot)
 
-                print("#####")
-                print(slot)
-                print(other_slot_mappings)
-
                 for other_slot_mapping in other_slot_mappings:
                     # check whether the slot should be filled
                     # by entity with the same name

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -685,6 +685,77 @@ def test_extract_other_slots_with_intent():
     assert slot_values == {"some_other_slot": "some_other_value"}
 
 
+def test_extract_other_slots_with_entity():
+    """Test extraction of other not requested slots values from entities with roles.
+    """
+
+    # noinspection PyAbstractClass
+    class CustomFormAction(FormAction):
+        def name(self):
+            return "some_form"
+
+        @staticmethod
+        def required_slots(_tracker):
+            return ["some_slot", "some_other_slot"]
+
+        def slot_mappings(self):
+            return {
+                "some_other_slot": self.from_entity(
+                    entity="some_other_slot", intent="some_intent", role="some_role"
+                )
+            }
+
+    form = CustomFormAction()
+
+    tracker = Tracker(
+        "default",
+        {"requested_slot": "some_slot"},
+        {
+            "intent": {"name": "some_other_intent", "confidence": 1.0},
+            "entities": [
+                {
+                    "entity": "some_other_slot",
+                    "value": "some_other_value",
+                    "role": "some_role",
+                }
+            ],
+        },
+        [],
+        False,
+        None,
+        {},
+        "action_listen",
+    )
+
+    slot_values = form.extract_other_slots(CollectingDispatcher(), tracker, {})
+    # check that the value was extracted for non requested slot
+    assert slot_values == {}
+
+    tracker = Tracker(
+        "default",
+        {"requested_slot": "some_slot"},
+        {
+            "intent": {"name": "some_intent", "confidence": 1.0},
+            "entities": [
+                {
+                    "entity": "some_other_slot",
+                    "value": "some_other_value",
+                    "role": "some_role",
+                }
+            ],
+        },
+        [],
+        False,
+        None,
+        {},
+        "action_listen",
+    )
+
+    slot_values = form.extract_other_slots(CollectingDispatcher(), tracker, {})
+    # check that the value was extracted only for non requested slot
+    assert slot_values == {"some_other_slot": "some_other_value"}
+
+
 async def test_validate():
     # noinspection PyAbstractClass
     class CustomFormAction(FormAction):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -704,13 +704,7 @@ def test_extract_other_slots_with_intent():
         (
             "some_role",
             None,
-            [
-                {
-                    "entity": "entity_type",
-                    "value": "some_value",
-                    "role": "some_role",
-                }
-            ],
+            [{"entity": "entity_type", "value": "some_value", "role": "some_role"}],
             "some_intent",
             {"some_other_slot": "some_value"},
         ),
@@ -730,13 +724,7 @@ def test_extract_other_slots_with_intent():
         (
             None,
             "some_group",
-            [
-                {
-                    "entity": "entity_type",
-                    "value": "some_value",
-                    "group": "some_group",
-                }
-            ],
+            [{"entity": "entity_type", "value": "some_value", "group": "some_group"}],
             "some_intent",
             {"some_other_slot": "some_value"},
         ),
@@ -757,27 +745,17 @@ def test_extract_other_slots_with_intent():
         (
             None,
             None,
-            [
-                {
-                    "entity": "some_entity",
-                    "value": "some_value",
-                }
-            ],
+            [{"entity": "some_entity", "value": "some_value"}],
             "some_intent",
             {},
         ),
         (
             None,
             None,
-            [
-                {
-                    "entity": "entity_type",
-                    "value": "some_value",
-                }
-            ],
+            [{"entity": "entity_type", "value": "some_value"}],
             "some_intent",
             {},
-        )
+        ),
     ],
 )
 def test_extract_other_slots_with_entity(
@@ -803,9 +781,7 @@ def test_extract_other_slots_with_entity(
         def slot_mappings(self):
             return {
                 "some_other_slot": self.from_entity(
-                    entity="entity_type",
-                    role=mapping_role,
-                    group=mapping_group,
+                    entity="entity_type", role=mapping_role, group=mapping_group
                 )
             }
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -686,11 +686,9 @@ def test_extract_other_slots_with_intent():
 
 
 @pytest.mark.parametrize(
-    "mapping_not_intent, mapping_intent, mapping_role, mapping_group, entities, intent, expected_slot_values",
+    "mapping_role, mapping_group, entities, intent, expected_slot_values",
     [
         (
-            None,
-            None,
             "some_role",
             None,
             [
@@ -704,8 +702,6 @@ def test_extract_other_slots_with_intent():
             {},
         ),
         (
-            None,
-            None,
             "some_role",
             None,
             [
@@ -719,8 +715,6 @@ def test_extract_other_slots_with_intent():
             {"some_other_slot": "some_value"},
         ),
         (
-            None,
-            None,
             None,
             "some_group",
             [
@@ -735,8 +729,6 @@ def test_extract_other_slots_with_intent():
         ),
         (
             None,
-            None,
-            None,
             "some_group",
             [
                 {
@@ -749,8 +741,6 @@ def test_extract_other_slots_with_intent():
             {"some_other_slot": "some_value"},
         ),
         (
-            None,
-            None,
             "some_role",
             "some_group",
             [
@@ -767,8 +757,6 @@ def test_extract_other_slots_with_intent():
         (
             None,
             None,
-            None,
-            None,
             [
                 {
                     "entity": "some_entity",
@@ -779,8 +767,6 @@ def test_extract_other_slots_with_intent():
             {},
         ),
         (
-            None,
-            None,
             None,
             None,
             [
@@ -795,13 +781,11 @@ def test_extract_other_slots_with_intent():
     ],
 )
 def test_extract_other_slots_with_entity(
-    mapping_not_intent,
-    mapping_intent,
-    mapping_role,
-    mapping_group,
-    entities,
-    intent,
-    expected_slot_values,
+    mapping_role: Optional[Text],
+    mapping_group: Optional[Text],
+    entities: List[Dict[Text, Any]],
+    intent: Text,
+    expected_slot_values: Dict[Text, Text],
 ):
     """Test extraction of other not requested slots values from entities with
     roles/groups.
@@ -820,8 +804,6 @@ def test_extract_other_slots_with_entity(
             return {
                 "some_other_slot": self.from_entity(
                     entity="entity_type",
-                    intent=mapping_intent,
-                    not_intent=mapping_not_intent,
                     role=mapping_role,
                     group=mapping_group,
                 )
@@ -832,7 +814,7 @@ def test_extract_other_slots_with_entity(
     tracker = Tracker(
         "default",
         {"requested_slot": "some_slot"},
-        {"intent": {"name": intent, "confidence": 1.0}, "entities": entities,},
+        {"intent": {"name": intent, "confidence": 1.0}, "entities": entities},
         [],
         False,
         None,

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -686,9 +686,10 @@ def test_extract_other_slots_with_intent():
 
 
 @pytest.mark.parametrize(
-    "mapping_role, mapping_group, entities, intent, expected_slot_values",
+    "mapping_entity, mapping_role, mapping_group, entities, intent, expected_slot_values",
     [
         (
+            "entity_type",
             "some_role",
             None,
             [
@@ -702,6 +703,7 @@ def test_extract_other_slots_with_intent():
             {},
         ),
         (
+            "entity_type",
             "some_role",
             None,
             [{"entity": "entity_type", "value": "some_value", "role": "some_role"}],
@@ -709,6 +711,7 @@ def test_extract_other_slots_with_intent():
             {"some_other_slot": "some_value"},
         ),
         (
+            "entity_type",
             None,
             "some_group",
             [
@@ -722,6 +725,7 @@ def test_extract_other_slots_with_intent():
             {},
         ),
         (
+            "entity_type",
             None,
             "some_group",
             [{"entity": "entity_type", "value": "some_value", "group": "some_group"}],
@@ -729,6 +733,7 @@ def test_extract_other_slots_with_intent():
             {"some_other_slot": "some_value"},
         ),
         (
+            "entity_type",
             "some_role",
             "some_group",
             [
@@ -743,6 +748,7 @@ def test_extract_other_slots_with_intent():
             {"some_other_slot": "some_value"},
         ),
         (
+            "entity_type",
             None,
             None,
             [{"entity": "some_entity", "value": "some_value"}],
@@ -750,24 +756,32 @@ def test_extract_other_slots_with_intent():
             {},
         ),
         (
+            "some_entity",
             None,
             None,
             [{"entity": "entity_type", "value": "some_value"}],
             "some_intent",
             {},
         ),
+        (
+            "entity_type",
+            None,
+            None,
+            [{"entity": "entity_type", "value": "some_value"}],
+            "some_intent",
+            {"some_other_slot": "some_value"},
+        ),
     ],
 )
 def test_extract_other_slots_with_entity(
+    mapping_entity: Text,
     mapping_role: Optional[Text],
     mapping_group: Optional[Text],
     entities: List[Dict[Text, Any]],
     intent: Text,
     expected_slot_values: Dict[Text, Text],
 ):
-    """Test extraction of other not requested slots values from entities with
-    roles/groups.
-    """
+    """Test extraction of other not requested slots values from entities."""
 
     # noinspection PyAbstractClass
     class CustomFormAction(FormAction):
@@ -781,7 +795,7 @@ def test_extract_other_slots_with_entity(
         def slot_mappings(self):
             return {
                 "some_other_slot": self.from_entity(
-                    entity="entity_type", role=mapping_role, group=mapping_group
+                    entity=mapping_entity, role=mapping_role, group=mapping_group
                 )
             }
 


### PR DESCRIPTION
**Proposed changes**:
Use the custom slot mapping 'from_entity' defined by the user to fill other slots.

Will be merged into `composite-entities`. We gonna collect some user feedback before we actually gonna merge this into master.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
