### PR TITLE
Fix ActionExecutor not loading some subclasses of Action

### DIFF
--- a/changelog/212.bugfix.rst
+++ b/changelog/212.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``ActionExecutor`` sometimes not loading user-defined actions that inherit from other user-defined ones.

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -146,7 +146,7 @@ TimestampModule = namedtuple("TimestampModule", ["timestamp", "module"])
 
 
 class ActionExecutor:
-    def __init__(self):
+    def __init__(self) -> None:
         self.actions = {}
         self._modules: Dict[Text, TimestampModule] = {}
         self._loaded: Set[Type] = set()

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 import pkgutil
 import warnings
-from typing import Text, List, Dict, Any, Type, Union, Callable, Optional
+from typing import Text, List, Dict, Any, Type, Union, Callable, Optional, Set
 from collections import namedtuple
 import typing
 import types
@@ -149,6 +149,7 @@ class ActionExecutor:
     def __init__(self):
         self.actions = {}
         self._modules: Dict[Text, TimestampModule] = {}
+        self._loaded: Set[Type] = set()
 
     def register_action(self, action: Union[Type["Action"], "Action"]) -> None:
         if inspect.isclass(action):
@@ -156,15 +157,12 @@ class ActionExecutor:
                 logger.warning(f"Skipping built in Action {action}.")
                 return
             else:
-                if getattr(action, "_sdk_loaded", False):
-                    # This Action subclass has already been loaded in the past;
-                    # do not try to load it again as either 1) it is already
-                    # loaded or 2) it has been replaced by a newer version
-                    # already.
+                # Check if this class has already been loaded in the past.
+                if action in self._loaded:
                     return
 
                 # Mark the class as "loaded"
-                action._sdk_loaded = True
+                self._loaded.add(action)
                 action = action()
 
         if isinstance(action, Action):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -3,6 +3,8 @@ import shutil
 import random
 import string
 import time
+
+from rasa_sdk import Action
 from typing import Text, Optional, Generator
 
 import pytest
@@ -197,3 +199,24 @@ async def test_reload_module(
         "image": None,
         "attachment": None,
     }
+
+
+class SubclassTestActionA(Action):
+    def name(self):
+        return "subclass_test_action_a"
+
+
+class SubclassTestActionB(SubclassTestActionA):
+    def name(self):
+        return "subclass_test_action_b"
+
+
+def test_load_subclasses(executor: ActionExecutor):
+    executor.register_action(SubclassTestActionB)
+    assert list(executor.actions) == ["subclass_test_action_b"]
+
+    executor.register_action(SubclassTestActionA)
+    assert sorted(list(executor.actions)) == [
+        "subclass_test_action_a",
+        "subclass_test_action_b",
+    ]


### PR DESCRIPTION
**Proposed changes**:
Fix `ActionExecutor` class sometimes not loading some `Action` subclasses, in cases where a user-defined action inherited from another user-defined action.

Closes https://github.com/RasaHQ/rasa-sdk/issues/204/.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
