### PR TITLE
Proper Abstract Action Check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ venv.bak/
 # mypy
 .mypy_cache/
 .idea/
+.vscode/
 examples/moodbot/models/
 
 # emacs

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -261,25 +261,14 @@ class ActionExecutor:
         actions = utils.all_subclasses(Action)
 
         for action in actions:
-            logger.debug(f"checking action {action.__module__}")
-
             if (
-                action.__module__.startswith("rasa_core.")
-                or action.__module__.startswith("rasa.")
-                or action.__module__.startswith("rasa_sdk.")
-                or action.__module__.startswith("rasa_core_sdk.")
+                not action.__module__.startswith("rasa_core.")
+                and not action.__module__.startswith("rasa.")
+                and not action.__module__.startswith("rasa_sdk.")
+                and not action.__module__.startswith("rasa_core_sdk.")
+                and not inspect.isabstract(action)
             ):
-                logger.debug(f"skipping action {action.__module__}")
-                continue
-
-            try:
-                if not (inspect.isabstract(action) and inspect.isabstract(action())):
-                    logger.debug(f'registering action {action.__module__}')
-                    self.register_action(action)
-            except TypeError as e:
-                # it errors because of abstract class being instantiated
-                logger.error(e, exc_info=True)
-                logger.debug(f"skipping {action.__module__} since it is abstract")
+                self.register_action(action)
 
     def _find_modules_to_reload(self) -> Dict[Text, TimestampModule]:
         """Finds all Python modules that should be reloaded by checking their

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -273,15 +273,13 @@ class ActionExecutor:
                 continue
 
             try:
-                logger.debug(inspect.isabstract(action))
-                logger.debug(inspect.isabstract(action()))
                 if not (inspect.isabstract(action) and inspect.isabstract(action())):
                     logger.debug(f'registering action {action.__module__}')
                     self.register_action(action)
             except TypeError as e:
                 # it errors because of abstract class being instantiated
+                logger.error(e, exc_info=True)
                 logger.debug(f"skipping {action.__module__} since it is abstract")
-                continue
 
     def _find_modules_to_reload(self) -> Dict[Text, TimestampModule]:
         """Finds all Python modules that should be reloaded by checking their

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -220,3 +220,37 @@ def test_load_subclasses(executor: ActionExecutor):
         "subclass_test_action_a",
         "subclass_test_action_b",
     ]
+
+def test_load_abstract_classes(executor: ActionExecutor, package_path: Text):
+    ABSTRACT_ACTION_TEST_TEMPLATE = """
+from abc import ABC, abstractmethod
+
+from rasa_sdk import Action
+
+class AbstractTestAction(ABC, Action):
+    @abstractmethod
+    def name(self):
+        return "abstract_test_action"
+
+    @abstractmethod
+    async def run(self, dispatcher, tracker, domain):
+        dispatcher.utter_message("abstract test action")
+        return []
+
+class TestConcreteAction(AbstractTestAction):
+    def name(self):
+        return "concrete_test_action"
+
+    async def run(self, dispatcher, tracker, domain):
+        dispatcher.utter_message("concrete test action")
+        return []
+    """
+
+    # set up the file
+    with open(os.path.join(package_path, "__init__.py"), "w") as f:
+        f.write(ABSTRACT_ACTION_TEST_TEMPLATE)
+
+    executor.register_package(package_path.replace("/", "."))
+    # abstract_test_action shouldn't exist in this executor actions list
+    assert "abstract_test_action" not in executor.actions
+    assert "concrete_test_action" in executor.actions

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -221,6 +221,7 @@ def test_load_subclasses(executor: ActionExecutor):
         "subclass_test_action_b",
     ]
 
+
 def test_load_abstract_classes(executor: ActionExecutor, package_path: Text):
     ABSTRACT_ACTION_TEST_TEMPLATE = """
 from abc import ABC, abstractmethod


### PR DESCRIPTION
~This change tries to resolve issue 233 , since the `inpsect.isabstract()` only works on instantiated class instances.~

Edit: As I was working on this by adding unit test, I found that the original code also passes the test, so there is no need for the code change. I am going to commit just the unit test to cover the abstract action register, so hopefully it is still usefull.

**Proposed changes**:
~- in the executor's `_register_all_actions()` method, we will try to instantiate the action class and make sure it is not abstract before we register.~
- Added unit test to cover the case with the abstract class check in ActionExecutor.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
