### PR TITLE
Only fill other slots if slot mapping contains a group/role restriction

### DIFF
--- a/changelog/237.enhancement.rst
+++ b/changelog/237.enhancement.rst
@@ -1,0 +1,1 @@
+Only fill other slots if slot mapping contains a role or group restriction.

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -190,38 +190,39 @@ class FormAction(Action):
         return intent_not_blacklisted or intent in mapping_intents
 
     def entity_is_desired(
-        self, requested_slot_mapping: Dict[Text, Any], slot: Text, tracker: "Tracker"
+        self, other_slot_mapping: Dict[Text, Any], other_slot: Text, tracker: "Tracker"
     ) -> bool:
-        """Check whether slot should be filled by an entity in the input or not.
+        """Check whether the other slot should be filled by an entity in the input or
+        not.
 
         Args:
-            requested_slot_mapping: Slot mapping.
-            slot: The slot to be filled.
+            other_slot_mapping: Slot mapping.
+            other_slot: The other slot to be filled.
             tracker: The tracker.
 
         Returns:
-            True, if slot should be filled, false otherwise.
+            True, if other slot should be filled, false otherwise.
         """
 
         # slot name is equal to the entity type
-        slot_equals_entity = slot == requested_slot_mapping.get("entity")
+        other_slot_equals_entity = other_slot == other_slot_mapping.get("entity")
 
         # use the custom slot mapping 'from_entity' defined by the user to check
         # whether we can fill a slot with an entity
-        slot_fulfils_entity_mapping = False
+        other_slot_fulfils_entity_mapping = False
         if (
-            requested_slot_mapping.get("role") is not None
-            or requested_slot_mapping.get("group") is not None
+            other_slot_mapping.get("role") is not None
+            or other_slot_mapping.get("group") is not None
         ):
             matching_values = self.get_entity_value(
-                requested_slot_mapping.get("entity"),
+                other_slot_mapping.get("entity"),
                 tracker,
-                requested_slot_mapping.get("role"),
-                requested_slot_mapping.get("group"),
+                other_slot_mapping.get("role"),
+                other_slot_mapping.get("group"),
             )
-            slot_fulfils_entity_mapping = matching_values is not None
+            other_slot_fulfils_entity_mapping = matching_values is not None
 
-        return slot_equals_entity or slot_fulfils_entity_mapping
+        return other_slot_equals_entity or other_slot_fulfils_entity_mapping
 
     @staticmethod
     def get_entity_value(

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -208,13 +208,18 @@ class FormAction(Action):
 
         # use the custom slot mapping 'from_entity' defined by the user to check
         # whether we can fill a slot with an entity
-        matching_values = self.get_entity_value(
-            requested_slot_mapping.get("entity"),
-            tracker,
-            requested_slot_mapping.get("role"),
-            requested_slot_mapping.get("group"),
-        )
-        slot_fulfils_entity_mapping = matching_values is not None
+        slot_fulfils_entity_mapping = False
+        if (
+            requested_slot_mapping.get("role") is not None
+            or requested_slot_mapping.get("group") is not None
+        ):
+            matching_values = self.get_entity_value(
+                requested_slot_mapping.get("entity"),
+                tracker,
+                requested_slot_mapping.get("role"),
+                requested_slot_mapping.get("group"),
+            )
+            slot_fulfils_entity_mapping = matching_values is not None
 
         return slot_equals_entity or slot_fulfils_entity_mapping
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -769,7 +769,7 @@ def test_extract_other_slots_with_intent():
             None,
             [{"entity": "entity_type", "value": "some_value"}],
             "some_intent",
-            {"some_other_slot": "some_value"},
+            {},
         ),
     ],
 )


### PR DESCRIPTION
**Proposed changes**:
Only fill other slots if slot mapping contains a role or group restriction.

related to [forum post](https://forum.rasa.com/t/same-training-data-for-multiple-entities-issue/31285/5
)
closes #218 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
