### PR TITLE
add helper to extract form slot candidates

### DIFF
--- a/changelog/238.feature.rst
+++ b/changelog/238.feature.rst
@@ -1,0 +1,32 @@
+Added the method ``form_slots_to_validate`` to ``Tracker``. This method is helpful
+when using a custom action to validate slots which were extracted by a Form as shown
+by the following example.
+
+.. code-block:: python
+
+    class ValidateSlots(Action):
+        def name(self) -> Text:
+            return "validate_your_form"
+
+        def run(
+            self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
+        ) -> List[EventType]:
+            extracted_slots: Dict[Text, Any] = tracker.form_slots_to_validate()
+
+            validation_events = []
+
+            for slot_name, slot_value in extracted_slots:
+                # Check if slot is valid.
+                if is_valid(slot_value):
+                    validation_events.append(SlotSet(slot_name, slot_value))
+                else:
+                    # Return a `SlotSet` event with value `None` to indicate that this
+                    # slot still needs to be filled.
+                    validation_events.append(SlotSet(slot_name, None))
+
+            return validation_events
+
+        def is_valid(slot_value: Any) -> bool:
+            # Implementation of the validate function.
+
+ Please note that ``tracker.form_slots_to_validate`` only works with Rasa Open Source 2.

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -228,6 +228,34 @@ class Tracker:
                 applied_events.append(event)
         return applied_events
 
+    def form_slots_to_validate(self) -> Dict[Text, Any]:
+        """Get form slots which need validation.
+
+        You can use a custom action to validate slots which were extracted during the
+        latest form execution. This method provides you all extracted candidates for
+        form slots.
+
+        Returns:
+            A mapping of extracted slot candidates and their values.
+        """
+
+        slots_to_validate = {}
+
+        if not self.active_loop:
+            return slots_to_validate
+
+        for event in reversed(self.events):
+            # The `FormAction` in Rasa Open Source will append all slot candidates
+            # at the end of the tracker events.
+            if event["event"] == "slot":
+                slots_to_validate[event["name"]] = event["value"]
+            else:
+                # Stop as soon as there is another event type as this means that we
+                # checked all potential slot candidates.
+                break
+
+        return slots_to_validate
+
 
 class Action:
     """Next action to be taken in response to a dialogue state."""


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa-sdk/issues/238
- add a method `form_slots_to_validate` to `Tracker` to make it easier to retrieve extracted slot candidates from a form

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation (I'll need to update the Rasa Open Source 2.x docs as I used the placeholder name `get_extracted_slots` there
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
