### PR TITLE
Fix event type used in applied events function

### DIFF
--- a/changelog/280.bugfix.md
+++ b/changelog/280.bugfix.md
@@ -1,0 +1,1 @@
+`tracker.applied_events` now correctly deals with restart, undo, and rewind events

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -218,11 +218,12 @@ class Tracker:
 
         applied_events: List[Dict[Text, Any]] = []
         for event in self.events:
-            if event.get("name") == "restart":
+            event_type = event.get("event")
+            if event_type == "restart":
                 applied_events = []
-            elif event.get("name") == "undo":
+            elif event_type == "undo":
                 undo_till_previous("action", applied_events)
-            elif event.get("name") == "rewind":
+            elif event_type == "rewind":
                 # Seeing a user uttered event automatically implies there was
                 # a listen event right before it, so we'll first rewind the
                 # user utterance, then get the action right before it (also removes

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -57,7 +57,12 @@ def test_get_last_event_for_with_exclude():
 
 
 def test_applied_events_after_restart():
-    events = [ActionExecuted("one"), user_uttered("two", 1), Restarted(), ActionExecuted("three")]
+    events = [
+        ActionExecuted("one"),
+        user_uttered("two", 1),
+        Restarted(),
+        ActionExecuted("three"),
+    ]
 
     tracker = get_tracker(events)
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,7 +1,13 @@
 import pytest
 
 from rasa_sdk import Tracker
-from rasa_sdk.events import ActionExecuted, UserUttered, ActionReverted, SlotSet
+from rasa_sdk.events import (
+    ActionExecuted,
+    UserUttered,
+    ActionReverted,
+    SlotSet,
+    Restarted,
+)
 from rasa_sdk.interfaces import ACTION_LISTEN_NAME
 from typing import List, Dict, Text, Any
 
@@ -48,6 +54,14 @@ def test_get_last_event_for_with_exclude():
     tracker = get_tracker(events)
 
     assert tracker.get_last_event_for("action", exclude=["three"]).get("name") == "one"
+
+
+def test_applied_events_after_restart():
+    events = [ActionExecuted("one"), user_uttered("two", 1), Restarted(), ActionExecuted("three")]
+
+    tracker = get_tracker(events)
+
+    assert tracker.applied_events() == [ActionExecuted("three")]
 
 
 def test_last_executed_has():


### PR DESCRIPTION
**Proposed changes**:
The `applied_events` function was using the event name instead of the event type when checking if an event was a `restart`, `rewind` or `undo`. This PR fixes #280.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
