### PR TITLE
add support for `LoopInterrupted` event

### DIFF
--- a/changelog/6463.improvement.md
+++ b/changelog/6463.improvement.md
@@ -1,0 +1,1 @@
+Added support for the `LoopInterrupted` event.

--- a/changelog/6463.removal.md
+++ b/changelog/6463.removal.md
@@ -1,0 +1,3 @@
+The `FormValidation` event was renamed to `LoopInterrupted` as part of Rasa Open Source
+2.0. Using the `FormValidation` is now deprecated and will be removed in the future.
+Please use `LoopInterrupted` instead.

--- a/rasa_sdk/events.py
+++ b/rasa_sdk/events.py
@@ -184,8 +184,25 @@ def Form(name: Optional[Text], timestamp: Optional[float] = None) -> EventType:
 
 
 # noinspection PyPep8Naming
-def FormValidation(validate, timestamp: Optional[float] = None) -> EventType:
-    return {"event": "form_validation", "validate": validate, "timestamp": timestamp}
+def LoopInterrupted(
+    is_interrupted: bool, timestamp: Optional[float] = None
+) -> EventType:
+    return {
+        "event": "loop_interrupted",
+        "is_interrupted": is_interrupted,
+        "timestamp": timestamp,
+    }
+
+
+# noinspection PyPep8Naming
+def FormValidation(validate: bool, timestamp: Optional[float] = None) -> EventType:
+    warnings.warn(
+        f"The {FormValidation.__name__}` event is deprecated. Please use the "
+        f"`{LoopInterrupted.__name__}` event instead.",
+        DeprecationWarning,
+    )
+    # `validate = False` is the same as `is_interrupted = True`
+    return LoopInterrupted(not validate, timestamp)
 
 
 # noinspection PyPep8Naming

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -18,6 +18,8 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 # to do the form handling
 REQUESTED_SLOT = "requested_slot"
 
+LOOP_INTERRUPTED_KEY = "is_interrupted"
+
 
 class FormAction(Action):
     def __init__(self):
@@ -588,7 +590,7 @@ class FormAction(Action):
         # no active_loop means that it is called during activation
         need_validation = not tracker.active_loop or (
             tracker.latest_action_name == "action_listen"
-            and tracker.active_loop.get("validate", True)
+            and not tracker.active_loop.get(LOOP_INTERRUPTED_KEY, False)
         )
         if need_validation:
             logger.debug(f"Validating user input '{tracker.latest_message}'")
@@ -670,8 +672,7 @@ class FormAction(Action):
         return f"FormAction('{self.name()}')"
 
     def _get_entity_type_of_slot_to_fill(
-        self,
-        slot_to_fill: Optional[Text],
+        self, slot_to_fill: Optional[Text],
     ) -> Optional[Text]:
         if not slot_to_fill:
             return None

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -672,7 +672,8 @@ class FormAction(Action):
         return f"FormAction('{self.name()}')"
 
     def _get_entity_type_of_slot_to_fill(
-        self, slot_to_fill: Optional[Text],
+        self,
+        slot_to_fill: Optional[Text],
     ) -> Optional[Text]:
         if not slot_to_fill:
             return None

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -38,3 +38,15 @@ def test_deprecation_warning_form_event():
             "event": "active_loop",
             "timestamp": timestamp,
         }
+
+
+@pytest.mark.parametrize("validate", [True, False])
+def test_deprecated_form_validation_event(validate: bool):
+    timestamp = 123
+    with pytest.warns(DeprecationWarning):
+        event = events.FormValidation(validate, timestamp=timestamp)
+        assert event == {
+            "is_interrupted": not validate,
+            "event": "loop_interrupted",
+            "timestamp": timestamp,
+        }

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -5,7 +5,7 @@ from typing import Type, Text, Dict, Any, List, Optional
 from rasa_sdk import Tracker, ActionExecutionRejection
 from rasa_sdk.events import SlotSet, ActiveLoop
 from rasa_sdk.executor import CollectingDispatcher
-from rasa_sdk.forms import FormAction, REQUESTED_SLOT
+from rasa_sdk.forms import FormAction, REQUESTED_SLOT, LOOP_INTERRUPTED_KEY
 
 
 def test_extract_requested_slot_default():
@@ -569,7 +569,7 @@ def test_extract_trigger_slots():
         [],
         False,
         None,
-        {"name": "some_form", "validate": True, "rejected": False},
+        {"name": "some_form", LOOP_INTERRUPTED_KEY: False, "rejected": False},
         "action_listen",
     )
 
@@ -1127,7 +1127,7 @@ async def test_validate_trigger_slots():
         None,
         {
             "name": "some_form",
-            "validate": True,
+            LOOP_INTERRUPTED_KEY: False,
             "rejected": False,
             "trigger_message": {
                 "intent": {"name": "trigger_intent", "confidence": 1.0}
@@ -1152,7 +1152,7 @@ async def test_validate_trigger_slots():
         None,
         {
             "name": "some_form",
-            "validate": True,
+            LOOP_INTERRUPTED_KEY: False,
             "rejected": False,
             "trigger_message": {
                 "intent": {"name": "trigger_intent", "confidence": 1.0}
@@ -1210,7 +1210,7 @@ async def test_activate_if_required():
         [],
         False,
         None,
-        {"name": "some_form", "validate": True, "rejected": False},
+        {"name": "some_form", LOOP_INTERRUPTED_KEY: False, "rejected": False},
         "action_listen",
     )
 
@@ -1245,7 +1245,7 @@ async def test_validate_if_required():
         [],
         False,
         None,
-        {"name": "some_form", "validate": True, "rejected": False},
+        {"name": "some_form", LOOP_INTERRUPTED_KEY: False, "rejected": False},
         "action_listen",
     )
 
@@ -1271,12 +1271,12 @@ async def test_validate_if_required():
         [],
         False,
         None,
-        {"name": "some_form", "validate": False, "rejected": False},
+        {"name": "some_form", LOOP_INTERRUPTED_KEY: True, "rejected": False},
         "action_listen",
     )
 
     events = await form._validate_if_required(CollectingDispatcher(), tracker, {})
-    # check that validation was skipped because 'validate': False
+    # check that validation was skipped because loop was interrupted
     assert events == []
 
     tracker = Tracker(
@@ -1291,7 +1291,7 @@ async def test_validate_if_required():
         [],
         False,
         None,
-        {"name": "some_form", "validate": True, "rejected": False},
+        {"name": "some_form", LOOP_INTERRUPTED_KEY: False, "rejected": False},
         "some_form",
     )
 
@@ -1440,7 +1440,7 @@ async def test_early_deactivation(form_class: Type[FormAction]):
         [],
         False,
         None,
-        {"name": "some_form", "validate": True, "rejected": False},
+        {"name": "some_form", LOOP_INTERRUPTED_KEY: False, "rejected": False},
         "action_listen",
     )
 
@@ -1480,7 +1480,7 @@ async def test_submit(form_class: Type[FormAction]):
         [],
         False,
         None,
-        {"name": "some_form", "validate": False, "rejected": False},
+        {"name": "some_form", LOOP_INTERRUPTED_KEY: True, "rejected": False},
         "action_listen",
     )
 


### PR DESCRIPTION
**Proposed changes**:
- SDK part of https://github.com/RasaHQ/rasa/issues/6463
- `FormValidation` was renamed in Rasa Open Source. It's now called `LoopInterrupted`. 
- deprecate `FormValidation`
- add support for `LoopInterrupted` event
- adapt legacy `FormAction` to use `is_interrupted` instead of old `validate` key

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
