### PR TITLE
Update `FormValidationAction` to replace `-` with `_` in slot name

### DIFF
--- a/changelog/294.improvement.md
+++ b/changelog/294.improvement.md
@@ -1,0 +1,1 @@
+Update `FormValidationAction` to automatically replace `-` with `_` in slot name for validation function.

--- a/changelog/294.improvement.md
+++ b/changelog/294.improvement.md
@@ -1,1 +1,0 @@
-Update `FormValidationAction` to automatically replace `-` with `_` in slot name for validation function.

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -716,7 +716,7 @@ class FormValidationAction(Action, ABC):
         slots: Dict[Text, Any] = tracker.slots_to_validate()
 
         for slot_name, slot_value in slots.items():
-            function_name = f"validate_{slot_name}"
+            function_name = f"validate_{slot_name.replace('-','_')}"
             validate_func = getattr(self, function_name, None)
 
             if not validate_func:

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1619,3 +1619,44 @@ async def test_form_validation_without_validate_function():
             SlotSet("slot2", None),
             SlotSet("slot1", "validated_value"),
         ]
+
+
+async def test_form_validation_dash_slot():
+    class TestFormValidationDashSlotAction(FormValidationAction):
+        def name(self) -> Text:
+            return "some_form"
+
+        def validate_slot_with_dash(
+            self,
+            slot_value: Any,
+            dispatcher: "CollectingDispatcher",
+            tracker: "Tracker",
+            domain: "DomainDict",
+        ) -> Dict[Text, Any]:
+            if slot_value == "correct_value":
+                return {
+                    "slot-with-dash": "validated_value",
+                }
+            return {
+                "slot-with-dash": None,
+            }
+
+    form = TestFormValidationDashSlotAction()
+
+    # tracker with active form
+    tracker = Tracker(
+        "default",
+        {},
+        {},
+        [SlotSet("slot-with-dash", "correct_value")],
+        False,
+        None,
+        {"name": "some_form", "is_interrupted": False, "rejected": False},
+        "action_listen",
+    )
+
+    dispatcher = CollectingDispatcher()
+    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain=None)
+    assert events == [
+        SlotSet("slot-with-dash", "validated_value"),
+    ]


### PR DESCRIPTION
**Proposed changes**:
- update `FormValidationAction` to automatically replace `-` with `_` in slot name for validation function (based on 2.0 feedback)

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
