### PR TITLE
Redirections Redux

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,0 +1,5 @@
+# FIXME: this requires some feedback as to the 404, like in the website
+[[redirects]]
+  from = "/docs/action-server/*"
+  to = "/docs/action-server/index.html"
+  status = 404

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "start": "yarn pre-build && yarn develop",
     "develop": "docusaurus start --port 3002",
     "pre-build": "yarn copy-md-files && yarn variables && yarn included-sources && yarn program-outputs",
-    "build": "docusaurus build",
+    "build": "docusaurus build --out-dir build/docs/action-server",
     "serve": "netlify dev --dir=build --port=5002",
     "swizzle": "docusaurus swizzle",
     "new-version": "docusaurus docs:version",

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,1 +1,0 @@
-/docs/action-server/* /:splat 200!


### PR DESCRIPTION
This PR changes the build path of the `docusaurus build` command to match the subpath configured as `baseUrl` in `docusarus.config.js`. Doing this avoids the additional rewrite of sub-directory paths back to the root, and enables content 301 redirections to be maintained in this repo, rather than in `rasa-website`.

This corresponds to [this PR on rasa-website](https://github.com/RasaHQ/rasa-website/pull/864), which should be merged first.

NOTE: the `/docs/static/_redirects` file has been replaced by a `/docs/netlify.toml` instead, because due to the changed build path it would now end up in a subfolder where it wouldn't work. Depending on how the build/deploy is scripted, `netlify.toml` may not work. In this case we could revert to `_redirects`, but would have to place the `_redirects` file manually at the root of the build, as part of the script, not in `/static/`.
