### PR TITLE
Custom and dynamic slots

### DIFF
--- a/changelog/329.feature.md
+++ b/changelog/329.feature.md
@@ -1,5 +1,5 @@
 Extend the `FormValidation` action with support for extracting slots. If you
-want to extract a custom slot, add the slots name to the list of `missing_slots`
+want to extract a custom slot, add the slots name to the list of `custom_slots`
 and add a method `extract<slot name>` to your action:
 
 ```python
@@ -13,14 +13,13 @@ class FormWithSlotExtractions(FormValidationAction):
     def name(self) -> Text:
         return "some_form"
 
-    async def missing_slots(
+    async def custom_slots(
         self,
         dispatcher: "CollectingDispatcher",
         tracker: "Tracker",
         domain: "DomainDict",
     ) -> Optional[List[Text]]:
-        all_required_slots = ["my slot"]
-        return [slot for slot in all_required_slots if not tracker.slots.get(slot)]
+        return ["my slot"]
 
     async def extract_my_slot(
         self,
@@ -31,5 +30,6 @@ class FormWithSlotExtractions(FormValidationAction):
         return {"my_slot": "some value"}
 ```
 
-If all `missing_slots` are filled, the action will automatically return an event
-to disable the form.
+If all `custom_slots` are filled, the action will automatically return an event
+to disable the form. If not every custom slot is filled, the SDK will return an event
+to Rasa Open Source to fill the first missing slot next.

--- a/changelog/329.feature.md
+++ b/changelog/329.feature.md
@@ -1,5 +1,5 @@
 Extend the `FormValidation` action with support for extracting slots. If you
-want to extract a custom slot, add the slots name to the list of `custom_slots`
+want to extract a custom slot, add the slots name to the list of `required_slots`
 and add a method `extract<slot name>` to your action:
 
 ```python
@@ -13,7 +13,7 @@ class FormWithSlotExtractions(FormValidationAction):
     def name(self) -> Text:
         return "some_form"
 
-    async def custom_slots(
+    async def required_slots(
         self,
         dispatcher: "CollectingDispatcher",
         tracker: "Tracker",
@@ -30,6 +30,7 @@ class FormWithSlotExtractions(FormValidationAction):
         return {"my_slot": "some value"}
 ```
 
-If all `custom_slots` are filled, the action will automatically return an event
-to disable the form. If not every custom slot is filled, the SDK will return an event
+If all `required_slots` and all form slots which are specified in the domain are filled,
+the action will automatically return an event to disable the form. 
+If not every custom slot is filled, the SDK will return an event
 to Rasa Open Source to fill the first missing slot next.

--- a/changelog/329.feature.md
+++ b/changelog/329.feature.md
@@ -1,0 +1,35 @@
+Extend the `FormValidation` action with support for extracting slots. If you
+want to extract a custom slot, add the slots name to the list of `missing_slots`
+and add a method `extract<slot name>` to your action:
+
+```python
+from typing import Text, Dict, Any, List, Optional
+
+from rasa_sdk.forms import (
+    FormValidationAction,
+)
+
+class FormWithSlotExtractions(FormValidationAction):
+    def name(self) -> Text:
+        return "some_form"
+
+    async def missing_slots(
+        self,
+        dispatcher: "CollectingDispatcher",
+        tracker: "Tracker",
+        domain: "DomainDict",
+    ) -> Optional[List[Text]]:
+        all_required_slots = ["my slot"]
+        return [slot for slot in all_required_slots if not tracker.slots.get(slot)]
+
+    async def extract_my_slot(
+        self,
+        dispatcher: "CollectingDispatcher",
+        tracker: "Tracker",
+        domain: "DomainDict",
+    ) -> Dict[Text, Any]:
+        return {"my_slot": "some value"}
+```
+
+If all `missing_slots` are filled, the action will automatically return an event
+to disable the form.

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -386,10 +386,9 @@ class ActionExecutor:
             tracker = Tracker.from_dict(tracker_json)
             dispatcher = CollectingDispatcher()
 
-            if utils.is_coroutine_action(action):
-                events = await action(dispatcher, tracker, domain)
-            else:
-                events = action(dispatcher, tracker, domain)
+            events = await utils.call_potential_coroutine(
+                action(dispatcher, tracker, domain)
+            )
 
             if not events:
                 # make sure the action did not just return `None`...

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -719,7 +719,7 @@ class FormValidationAction(Action, ABC):
                 `tracker.get_slot(slot_name)`, the most recent user message
                 is `tracker.latest_message.text` and any other
                 `rasa_sdk.Tracker` property.
-            domain: the bot's domain
+            domain: the bot's domain.
 
         Returns:
             `SlotSet` for any extracted slots.

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -657,7 +657,8 @@ class FormAction(Action):
         return f"FormAction('{self.name()}')"
 
     def _get_entity_type_of_slot_to_fill(
-        self, slot_to_fill: Optional[Text],
+        self,
+        slot_to_fill: Optional[Text],
     ) -> Optional[Text]:
         if not slot_to_fill:
             return None

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -1,7 +1,7 @@
 import logging
 import typing
 import warnings
-from typing import Dict, Text, Any, List, Union, Optional, Tuple, cast
+from typing import Dict, Text, Any, List, Union, Optional, Tuple
 
 from abc import ABC
 from rasa_sdk import utils

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -657,8 +657,7 @@ class FormAction(Action):
         return f"FormAction('{self.name()}')"
 
     def _get_entity_type_of_slot_to_fill(
-        self,
-        slot_to_fill: Optional[Text],
+        self, slot_to_fill: Optional[Text],
     ) -> Optional[Text]:
         if not slot_to_fill:
             return None
@@ -897,6 +896,4 @@ class FormValidationAction(Action, ABC):
         ]
 
     def slots_mapped_in_domain(self, domain: "DomainDict") -> List[Text]:
-        return list(
-            domain.get("forms", {}).get(self.name(), {}).keys()
-        )
+        return list(domain.get("forms", {}).get(self.name(), {}).keys())

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -405,12 +405,9 @@ class FormAction(Action):
 
         for slot, value in list(slot_dict.items()):
             validate_func = getattr(self, f"validate_{slot}", lambda *x: {slot: value})
-            if utils.is_coroutine_action(validate_func):
-                validation_output = await validate_func(
-                    value, dispatcher, tracker, domain
-                )
-            else:
-                validation_output = validate_func(value, dispatcher, tracker, domain)
+            validation_output = await utils.call_potential_coroutine(
+                validate_func(value, dispatcher, tracker, domain)
+            )
             if not isinstance(validation_output, dict):
                 warnings.warn(
                     "Returning values in helper validation methods is deprecated. "
@@ -595,13 +592,9 @@ class FormAction(Action):
         )
         if need_validation:
             logger.debug(f"Validating user input '{tracker.latest_message}'")
-            if utils.is_coroutine_action(self.validate):
-                return await self.validate(dispatcher, tracker, domain)
-            else:
-                # see https://github.com/python/mypy/issues/5206
-                return cast(
-                    List[Dict[Text, Any]], self.validate(dispatcher, tracker, domain)
-                )
+            return await utils.call_potential_coroutine(
+                self.validate(dispatcher, tracker, domain)
+            )
         else:
             logger.debug("Skipping validation")
             return []
@@ -651,21 +644,12 @@ class FormAction(Action):
                 # there is nothing more to request, so we can submit
                 self._log_form_slots(temp_tracker)
                 logger.debug(f"Submitting the form '{self.name()}'")
-                if utils.is_coroutine_action(self.submit):
-                    events.extend(await self.submit(dispatcher, temp_tracker, domain))
-                else:
-                    # see https://github.com/python/mypy/issues/5206
-                    events.extend(
-                        cast(
-                            List[EventType],
-                            self.submit(dispatcher, temp_tracker, domain),
-                        )
-                    )
+                events += await utils.call_potential_coroutine(
+                    self.submit(dispatcher, temp_tracker, domain)
+                )
+
                 # deactivate the form after submission
-                if utils.is_coroutine_action(self.deactivate):
-                    events.extend(await self.deactivate())  # type: ignore
-                else:
-                    events.extend(self.deactivate())
+                events += await utils.call_potential_coroutine(self.deactivate())
 
         return events
 
@@ -695,7 +679,104 @@ class FormAction(Action):
 
 
 class FormValidationAction(Action, ABC):
-    """An action that validates if every extracted slot is valid."""
+    """A helper class for slot validations and extractions of custom slots."""
+
+    async def run(
+        self,
+        dispatcher: "CollectingDispatcher",
+        tracker: "Tracker",
+        domain: "DomainDict",
+    ) -> List[EventType]:
+        extraction_events = await self.extract_custom_slots(dispatcher, tracker, domain)
+        tracker.add_slots(extraction_events)
+
+        validation_events = await self.validate(dispatcher, tracker, domain)
+        tracker.add_slots(validation_events)
+
+        next_slot = await self.next_requested_slot(dispatcher, tracker, domain)
+        if next_slot:
+            validation_events.append(next_slot)
+
+        # Validation events include events for extracted slots
+        return validation_events
+
+    async def extract_custom_slots(
+        self,
+        dispatcher: "CollectingDispatcher",
+        tracker: "Tracker",
+        domain: "DomainDict",
+    ) -> List[EventType]:
+        """Extracts custom slots using available `extract_<slot name>` methods.
+
+        Uses the information from `self.missing_slots` to gather which slots should
+        be extracted.
+
+        Args:
+            dispatcher: the dispatcher which is used to
+                send messages back to the user. Use
+                `dispatcher.utter_message()` for sending messages.
+            tracker: the state tracker for the current
+                user. You can access slot values using
+                `tracker.get_slot(slot_name)`, the most recent user message
+                is `tracker.latest_message.text` and any other
+                `rasa_sdk.Tracker` property.
+            domain: the bot's domain
+
+        Returns:
+            `SlotSet` for any extracted slots.
+        """
+        custom_slots = []
+        slots_to_extract = await self.missing_slots(dispatcher, tracker, domain)
+
+        if slots_to_extract is None:
+            return []
+
+        for slot_name in slots_to_extract:
+            method_name = f"extract_{slot_name.replace('-', '_')}"
+            extract_method = getattr(self, method_name, None)
+
+            if not extract_method:
+                warnings.warn(
+                    f"No method '{method_name}' found for slot "
+                    f"'{slot_name}'. Skipping extraction for this slot."
+                )
+                continue
+
+            extracted = await utils.call_potential_coroutine(
+                extract_method(dispatcher, tracker, domain)
+            )
+
+            if extracted:
+                custom_slots += [
+                    SlotSet(slot, value) for slot, value in extracted.items()
+                ]
+            else:
+                warnings.warn(
+                    f"Cannot extract `{slot_name}`: make sure the extract method "
+                    f"returns the correct output."
+                )
+
+        return custom_slots
+
+    async def missing_slots(
+        self,
+        dispatcher: "CollectingDispatcher",
+        tracker: "Tracker",
+        domain: "DomainDict",
+    ) -> Optional[List[Text]]:
+        """Returns the slots which still need to be filled.
+
+        Args:
+            dispatcher: the dispatcher which is used to
+                send messages back to the user.
+            tracker: the conversation tracker for the current user.
+            domain: the bot's domain.
+
+        Returns:
+            `None` in case this form doesn't extract any custom slots. Otherwise
+            returns the names of the slots which still need to be filled.
+        """
+        return None
 
     async def validate(
         self,
@@ -716,37 +797,63 @@ class FormValidationAction(Action, ABC):
         slots: Dict[Text, Any] = tracker.slots_to_validate()
 
         for slot_name, slot_value in list(slots.items()):
-            function_name = f"validate_{slot_name.replace('-','_')}"
-            validate_func = getattr(self, function_name, None)
+            method_name = f"validate_{slot_name.replace('-','_')}"
+            validate_method = getattr(self, method_name, None)
 
-            if not validate_func:
-                logger.debug(
-                    f"Skipping validation for `{slot_name}`: there is no validation function specified."
+            if not validate_method:
+                logger.warning(
+                    f"Skipping validation for `{slot_name}`: there is no validation "
+                    f"method specified."
                 )
                 continue
 
-            if utils.is_coroutine_action(validate_func):
-                validation_output = await validate_func(
-                    slot_value, dispatcher, tracker, domain
-                )
-            else:
-                validation_output = validate_func(
-                    slot_value, dispatcher, tracker, domain
-                )
+            validation_output = await utils.call_potential_coroutine(
+                validate_method(slot_value, dispatcher, tracker, domain)
+            )
 
             if validation_output:
                 slots.update(validation_output)
             else:
                 warnings.warn(
-                    f"Cannot validate `{slot_name}`: make sure the validation function returns the correct output."
+                    f"Cannot validate `{slot_name}`: make sure the validation method "
+                    f"returns the correct output."
                 )
 
         return [SlotSet(slot, value) for slot, value in slots.items()]
 
-    async def run(
+    async def next_requested_slot(
         self,
         dispatcher: "CollectingDispatcher",
         tracker: "Tracker",
         domain: "DomainDict",
-    ) -> List[EventType]:
-        return await self.validate(dispatcher, tracker, domain)
+    ) -> Optional[EventType]:
+        """Sets the next slot which should be requested.
+
+        Skips setting the next requested slot in case `missing_slots` was not
+        overridden.
+
+        Args:
+            dispatcher: the dispatcher which is used to
+                send messages back to the user.
+            tracker: the conversation tracker for the current user.
+            domain: the bot's domain.
+
+        Returns:
+            `None` in case `missing_slots` was not overridden and returns `None`.
+            Otherwise returns a `SlotSet` event for the next slot to be requested.
+            If the `SlotSet` event sets `requested_slot` to `None`, the form will be
+            deactivated.
+        """
+        required_slots = await self.missing_slots(dispatcher, tracker, domain)
+        if required_slots is None:
+            # It seems like `required_slots` wasn't overridden. In this case we
+            # leave the deactivation of the form to the `FormAction` within
+            # Rasa Open Source
+            return None
+
+        if not required_slots:
+            # No more required slots. Form can be deactivated.
+            return SlotSet(REQUESTED_SLOT, None)
+
+        # request next slot
+        return SlotSet(REQUESTED_SLOT, required_slots[0])

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -4,6 +4,8 @@ import typing
 import warnings
 from typing import Any, Dict, Iterator, List, Optional, Text
 
+from rasa_sdk.events import EventType
+
 if typing.TYPE_CHECKING:  # pragma: no cover
     from rasa_sdk.types import DomainDict, TrackerState
 
@@ -150,7 +152,7 @@ class Tracker:
     def idx_after_latest_restart(self) -> int:
         """Return the idx of the most recent restart in the list of events.
 
-        If the conversation has not been restarted, ``0`` is returned."""
+        If the conversation has not been restarted, `0` is returned."""
 
         idx = 0
         for i, event in enumerate(self.events):
@@ -257,6 +259,18 @@ class Tracker:
 
         return slots
 
+    def add_slots(self, slots: List[EventType]) -> None:
+        """Adds slots to the current tracker.
+
+        Args:
+            slots: `SlotSet` events.
+        """
+        for event in slots:
+            if not event.get("event") == "slot":
+                continue
+            self.slots[event["name"]] = event["value"]
+            self.events.append(event)
+
 
 class Action:
     """Next action to be taken in response to a dialogue state."""
@@ -277,15 +291,15 @@ class Action:
         Args:
             dispatcher: the dispatcher which is used to
                 send messages back to the user. Use
-                ``dispatcher.utter_message()`` for sending messages.
+                `dispatcher.utter_message()` for sending messages.
             tracker: the state tracker for the current
                 user. You can access slot values using
-                ``tracker.get_slot(slot_name)``, the most recent user message
-                is ``tracker.latest_message.text`` and any other
-                ``rasa_sdk.Tracker`` property.
+                `tracker.get_slot(slot_name)`, the most recent user message
+                is `tracker.latest_message.text` and any other
+                `rasa_sdk.Tracker` property.
             domain: the bot's domain
         Returns:
-            A dictionary of ``rasa_sdk.events.Event`` instances that is
+            A dictionary of `rasa_sdk.events.Event` instances that is
                 returned through the endpoint
         """
 

--- a/rasa_sdk/knowledge_base/actions.py
+++ b/rasa_sdk/knowledge_base/actions.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Text, Callable, Dict, List, Any, Optional, cast
+from typing import Text, Dict, List, Any
 
 from rasa_sdk import Action
 from rasa_sdk.events import SlotSet

--- a/rasa_sdk/knowledge_base/storage.py
+++ b/rasa_sdk/knowledge_base/storage.py
@@ -206,11 +206,9 @@ class InMemoryKnowledgeBase(KnowledgeBase):
 
         objects = self.data[object_type]
 
-        if utils.is_coroutine_action(self.get_key_attribute_of_object):
-            key_attribute = await self.get_key_attribute_of_object(object_type)
-        else:
-            # see https://github.com/python/mypy/issues/5206
-            key_attribute = cast(Text, self.get_key_attribute_of_object(object_type))
+        key_attribute = await utils.call_potential_coroutine(
+            self.get_key_attribute_of_object(object_type)
+        )
 
         # filter the objects by its key attribute, for example, 'id'
         objects_of_interest = list(
@@ -224,15 +222,9 @@ class InMemoryKnowledgeBase(KnowledgeBase):
         # if the object was referred to directly, we need to compare the representation
         # of each object with the given object identifier
         if not objects_of_interest:
-            if utils.is_coroutine_action(self.get_representation_function_of_object):
-                repr_function = await self.get_representation_function_of_object(
-                    object_type
-                )
-            else:
-                # see https://github.com/python/mypy/issues/5206
-                repr_function = cast(
-                    Callable, self.get_representation_function_of_object(object_type)
-                )
+            repr_function = await utils.call_potential_coroutine(
+                self.get_representation_function_of_object(object_type)
+            )
 
             objects_of_interest = list(
                 filter(

--- a/rasa_sdk/knowledge_base/storage.py
+++ b/rasa_sdk/knowledge_base/storage.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import random
-from typing import DefaultDict, Text, Callable, Dict, List, Any, Optional, cast
+from typing import DefaultDict, Text, Callable, Dict, List, Any, Optional
 from collections import defaultdict
 
 from rasa_sdk import utils

--- a/rasa_sdk/utils.py
+++ b/rasa_sdk/utils.py
@@ -169,10 +169,6 @@ def check_version_compatibility(rasa_version: Optional[Text]) -> None:
         )
 
 
-def is_coroutine_action(action) -> bool:
-    return inspect.iscoroutinefunction(action)
-
-
 def update_sanic_log_level() -> None:
     """Set the log level of sanic loggers.
 

--- a/rasa_sdk/utils.py
+++ b/rasa_sdk/utils.py
@@ -1,9 +1,10 @@
+import asyncio
 import inspect
 import logging
 import warnings
 import os
 
-from typing import AbstractSet, Any, List, Text, Optional
+from typing import AbstractSet, Any, List, Text, Optional, Coroutine, Union
 
 import rasa_sdk
 from rasa_sdk.constants import (
@@ -189,3 +190,12 @@ def update_sanic_log_level() -> None:
     logger.propagate = False
     error_logger.propagate = False
     access_logger.propagate = False
+
+
+async def call_potential_coroutine(
+    coroutine_or_return_value: Union[Any, Coroutine]
+) -> Any:
+    if asyncio.iscoroutine(coroutine_or_return_value):
+        return await coroutine_or_return_value
+
+    return coroutine_or_return_value

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -4,7 +4,6 @@ from rasa_sdk import Action, Tracker
 from rasa_sdk.events import SlotSet
 from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.types import DomainDict
-from rasa_sdk.utils import is_coroutine_action
 
 
 class CustomAsyncAction(Action):
@@ -31,8 +30,3 @@ class CustomAction(Action):
         domain: DomainDict,
     ) -> List[Dict[Text, Any]]:
         return [SlotSet("test", "bar")]
-
-
-def test_action_async_check():
-    assert not is_coroutine_action(CustomAction.run)
-    assert is_coroutine_action(CustomAsyncAction.run)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1677,7 +1677,7 @@ async def test_extract_and_validate_slot(
         def name(self) -> Text:
             return "some_form"
 
-        async def custom_slots(
+        async def required_slots(
             self,
             dispatcher: "CollectingDispatcher",
             tracker: "Tracker",
@@ -1734,7 +1734,7 @@ async def test_extract_slot_only():
         def name(self) -> Text:
             return "some_form"
 
-        async def custom_slots(
+        async def required_slots(
             self,
             dispatcher: "CollectingDispatcher",
             tracker: "Tracker",
@@ -1799,7 +1799,7 @@ async def test_ask_for_next_slot(
         def name(self) -> Text:
             return "some_form"
 
-        async def custom_slots(
+        async def required_slots(
             self,
             dispatcher: "CollectingDispatcher",
             tracker: "Tracker",

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1063,7 +1063,7 @@ async def test_validate_prefilled_slots():
     )
 
     events = await form._activate_if_required(
-        dispatcher=None, tracker=tracker, domain=None
+        dispatcher=None, tracker=tracker, domain={}
     )
     # check that the form was activated and prefilled slots were validated
     assert events == [
@@ -1073,7 +1073,7 @@ async def test_validate_prefilled_slots():
     ]
 
     events.extend(
-        await form._validate_if_required(dispatcher=None, tracker=tracker, domain=None)
+        await form._validate_if_required(dispatcher=None, tracker=tracker, domain={})
     )
 
     # check that entities picked up in input overwrite prefilled slots
@@ -1204,7 +1204,7 @@ async def test_activate_if_required():
     )
 
     events = await form._activate_if_required(
-        dispatcher=None, tracker=tracker, domain=None
+        dispatcher=None, tracker=tracker, domain={}
     )
     # check that the form was activated
     assert events == [ActiveLoop("some_form")]
@@ -1221,7 +1221,7 @@ async def test_activate_if_required():
     )
 
     events = await form._activate_if_required(
-        dispatcher=None, tracker=tracker, domain=None
+        dispatcher=None, tracker=tracker, domain={}
     )
     # check that the form was not activated again
     assert events == []
@@ -1334,7 +1334,7 @@ async def test_validate_on_activation():
         "action_listen",
     )
     dispatcher = CollectingDispatcher()
-    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain=None)
+    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain={})
     # check that the form was activated and validation was performed
     assert events == [
         ActiveLoop("some_form"),
@@ -1369,7 +1369,7 @@ async def test_validate_on_activation_with_other_action_after_user_utterance():
         "some_action",
     )
     dispatcher = CollectingDispatcher()
-    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain=None)
+    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain={})
     # check that the form was activated and validation was performed
     assert events == [
         ActiveLoop("some_form"),
@@ -1450,7 +1450,7 @@ async def test_early_deactivation(form_class: Type[FormAction]):
         "action_listen",
     )
 
-    events = await form.run(dispatcher=None, tracker=tracker, domain=None)
+    events = await form.run(dispatcher=None, tracker=tracker, domain={})
 
     # check that form was deactivated before requesting next slot
     assert events == [ActiveLoop(None), SlotSet(REQUESTED_SLOT, None)]
@@ -1491,7 +1491,7 @@ async def test_submit(form_class: Type[FormAction]):
     )
 
     form = form_class()
-    events = await form.run(dispatcher=None, tracker=tracker, domain=None)
+    events = await form.run(dispatcher=None, tracker=tracker, domain={})
 
     assert events[0]["value"] == 42
 
@@ -1565,7 +1565,7 @@ async def test_form_validation_action():
     )
 
     dispatcher = CollectingDispatcher()
-    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain=None)
+    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain={})
     assert events == [
         SlotSet("slot2", None),
         SlotSet("slot1", "validated_value"),
@@ -1588,7 +1588,7 @@ async def test_form_validation_action_async():
     )
 
     dispatcher = CollectingDispatcher()
-    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain=None)
+    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain={})
     assert events == [SlotSet("slot3", "validated_value")]
 
 
@@ -1613,7 +1613,7 @@ async def test_form_validation_without_validate_function():
 
     dispatcher = CollectingDispatcher()
     with pytest.warns(UserWarning):
-        events = await form.run(dispatcher=dispatcher, tracker=tracker, domain=None)
+        events = await form.run(dispatcher=dispatcher, tracker=tracker, domain={})
         assert events == [
             SlotSet("slot3", "some_value"),
             SlotSet("slot2", None),
@@ -1656,7 +1656,7 @@ async def test_form_validation_dash_slot():
     )
 
     dispatcher = CollectingDispatcher()
-    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain=None)
+    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain={})
     assert events == [
         SlotSet("slot-with-dash", "validated_value"),
     ]
@@ -1677,13 +1677,13 @@ async def test_extract_and_validate_slot(
         def name(self) -> Text:
             return "some_form"
 
-        async def missing_slots(
+        async def custom_slots(
             self,
             dispatcher: "CollectingDispatcher",
             tracker: "Tracker",
             domain: "DomainDict",
         ) -> List[Text]:
-            return [slot for slot in required_slots if not tracker.slots.get(slot)]
+            return required_slots
 
         async def extract_my_slot(
             self,
@@ -1718,7 +1718,7 @@ async def test_extract_and_validate_slot(
     )
 
     dispatcher = CollectingDispatcher()
-    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain=None)
+    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain={})
 
     assert events == [
         SlotSet(custom_slot, validated_value),
@@ -1734,14 +1734,13 @@ async def test_extract_slot_only():
         def name(self) -> Text:
             return "some_form"
 
-        async def missing_slots(
+        async def custom_slots(
             self,
             dispatcher: "CollectingDispatcher",
             tracker: "Tracker",
             domain: "DomainDict",
         ) -> List[Text]:
-            all_required_slots = [custom_slot]
-            return [slot for slot in all_required_slots if not tracker.slots.get(slot)]
+            return [custom_slot]
 
         async def extract_my_slot(
             self,
@@ -1766,7 +1765,7 @@ async def test_extract_slot_only():
     )
 
     dispatcher = CollectingDispatcher()
-    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain=None)
+    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain={})
 
     assert events == [
         SlotSet(custom_slot, unvalidated_value),
@@ -1775,30 +1774,38 @@ async def test_extract_slot_only():
 
 
 @pytest.mark.parametrize(
-    "requested_slot_event, expected_return_events",
+    "custom_slots, domain, expected_return_events",
     [
-        (None, []),
-        (SlotSet(REQUESTED_SLOT, None), [SlotSet(REQUESTED_SLOT, None)]),
+        (None, {}, []),
+        ([], {}, [SlotSet(REQUESTED_SLOT, None)]),
         (
-            SlotSet(REQUESTED_SLOT, "some value"),
+            ["some value"],
+            {},
             [SlotSet(REQUESTED_SLOT, "some value")],
+        ),
+        (
+            [],
+            {"forms": {"some_form": {"another_slot": []}}},
+            [SlotSet(REQUESTED_SLOT, "another_slot")],
         ),
     ],
 )
 async def test_ask_for_next_slot(
-    requested_slot_event: Optional[EventType], expected_return_events: List[EventType]
+    custom_slots: Optional[List[Text]],
+    domain: Dict,
+    expected_return_events: List[EventType],
 ):
     class TestFormRequestSlot(FormValidationAction):
         def name(self) -> Text:
             return "some_form"
 
-        async def next_requested_slot(
+        async def custom_slots(
             self,
             dispatcher: "CollectingDispatcher",
             tracker: "Tracker",
             domain: "DomainDict",
-        ) -> Optional[List[EventType]]:
-            return requested_slot_event
+        ) -> Optional[List[Text]]:
+            return custom_slots
 
     form = TestFormRequestSlot()
 
@@ -1815,5 +1822,5 @@ async def test_ask_for_next_slot(
     )
 
     dispatcher = CollectingDispatcher()
-    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain=None)
+    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain=domain)
     assert events == expected_return_events

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 import pytest
+from rasa_sdk.events import SlotSet
 
 from rasa_sdk.interfaces import Tracker
 
@@ -49,3 +50,14 @@ def test_active_loop_in_tracker_state():
     tracker = Tracker.from_dict(state)
 
     assert tracker.current_state()["active_loop"] == form
+
+
+def test_tracker_with_slots():
+    form = {"name": "my form"}
+    state = {"events": [], "sender_id": "old", "active_loop": form}
+    tracker = Tracker.from_dict(state)
+
+    tracker.add_slots([SlotSet("my slot", 5), SlotSet("my slot 2", None)])
+
+    assert tracker.slots["my slot"] == 5
+    assert tracker.slots["my slot 2"] is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
 import os
+from typing import Callable, Any
+
 import pytest
 
+import rasa_sdk.utils
 from rasa_sdk.utils import number_of_sanic_workers
 from rasa_sdk.constants import DEFAULT_SANIC_WORKERS, ENV_SANIC_WORKERS
 
@@ -20,3 +23,25 @@ def test_env_number_of_sanic_workers(n_workers):
 def test_invalid_env_number_of_sanic_workers(n_workers):
     os.environ[ENV_SANIC_WORKERS] = str(n_workers)
     assert number_of_sanic_workers() == DEFAULT_SANIC_WORKERS
+
+
+async def test_call_maybe_coroutine_with_async() -> Any:
+    expected = 5
+
+    async def my_function():
+        return expected
+
+    actual = await rasa_sdk.utils.call_potential_coroutine(my_function())
+
+    assert actual == expected
+
+
+async def test_call_maybe_coroutine_with_sync() -> Any:
+    expected = 5
+
+    def my_function():
+        return expected
+
+    actual = await rasa_sdk.utils.call_potential_coroutine(my_function())
+
+    assert actual == expected


### PR DESCRIPTION
**Proposed changes**:
- fix https://github.com/RasaHQ/rasa/issues/7156
- users can now override a method `required_slots` to specify slots which should be filled by the form. The `FormValidationAction` will look for a method `extract_<slot_name>` to extract these slots.
- in case the users overrode `required_slots`, the `FormValidationAction` will automatically set the `requested_slot` to the next `required_slot` which is currently not filled. Users can override this behavior by customizing `request_next_slot`. By default `request_next_slot` also considers slots which were mapped in the domain (if there were any mapped ones). 
- introduce a utility function `utils.call_potential_coroutine` to get rid of our checks `if is coroutine ... else ...`

I will update the Rasa Open Source documentation in a separate Rasa Open Source PR.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
