### PR TITLE
slot extractions v2

### DIFF
--- a/changelog/329.feature.md
+++ b/changelog/329.feature.md
@@ -20,7 +20,7 @@ class FormWithSlotExtractions(FormValidationAction):
         tracker: "Tracker",
         domain: "DomainDict",
     ) -> Optional[List[Text]]:
-        return slots_mapped_in_domain + ["my slot"]
+        return slots_mapped_in_domain + ["my_slot"]
 
     async def extract_my_slot(
         self,

--- a/changelog/329.feature.md
+++ b/changelog/329.feature.md
@@ -1,6 +1,6 @@
-Extend the `FormValidation` action with support for extracting slots. If you
-want to extract a custom slot, add the slots name to the list of `required_slots`
-and add a method `extract<slot name>` to your action:
+Extend `FormValidationAction` with support for extracting slots. If you
+want to extract an additional slot, add the slot's name to the list of `required_slots`
+and add a method `extract_<slot name>` to your action:
 
 ```python
 from typing import Text, Dict, Any, List, Optional
@@ -15,11 +15,12 @@ class FormWithSlotExtractions(FormValidationAction):
 
     async def required_slots(
         self,
+        slots_mapped_in_domain: List[Text],
         dispatcher: "CollectingDispatcher",
         tracker: "Tracker",
         domain: "DomainDict",
     ) -> Optional[List[Text]]:
-        return ["my slot"]
+        return slots_mapped_in_domain + ["my slot"]
 
     async def extract_my_slot(
         self,
@@ -30,7 +31,7 @@ class FormWithSlotExtractions(FormValidationAction):
         return {"my_slot": "some value"}
 ```
 
-If all `required_slots` and all form slots which are specified in the domain are filled,
+If all slots returned by `required_slots` are filled,
 the action will automatically return an event to disable the form. 
-If not every custom slot is filled, the SDK will return an event
+If not all required slots are filled, the SDK will return an event
 to Rasa Open Source to fill the first missing slot next.

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -657,7 +657,8 @@ class FormAction(Action):
         return f"FormAction('{self.name()}')"
 
     def _get_entity_type_of_slot_to_fill(
-        self, slot_to_fill: Optional[Text],
+        self,
+        slot_to_fill: Optional[Text],
     ) -> Optional[Text]:
         if not slot_to_fill:
             return None

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -744,20 +744,20 @@ class FormValidationAction(Action, ABC):
         domain: "DomainDict",
     ) -> List[EventType]:
         method_name = f"extract_{slot_name.replace('-', '_')}"
-        also_mapped_in_domain = slot_name in self.slots_mapped_in_domain(domain)
+        slot_mapped_in_domain = slot_name in self.slots_mapped_in_domain(domain)
         extract_method = getattr(self, method_name, None)
 
-        if not extract_method and not also_mapped_in_domain:
-            warnings.warn(
-                f"No method '{method_name}' found for slot "
-                f"'{slot_name}'. Skipping extraction for this slot."
-            )
-            return []
-
         if not extract_method:
-            return []
+            if not slot_mapped_in_domain:
+                warnings.warn(
+                    f"No method '{method_name}' found for slot "
+                    f"'{slot_name}'. Skipping extraction for this slot."
+                )
+                return []
+            else:
+                return []
 
-        if also_mapped_in_domain:
+        if extract_method and slot_mapped_in_domain:
             warnings.warn(
                 f"Slot '{slot_name}' is mapped in the domain and your custom "
                 f"action defines '{method_name}'. '{method_name}' will override any "
@@ -886,7 +886,7 @@ class FormValidationAction(Action, ABC):
         if required_slots and required_slots == self.slots_mapped_in_domain(domain):
             # If users didn't override `required_slots` then we'll let the `FormAction`
             # within Rasa Open Source request the next slot.
-            return
+            return None
 
         missing_slots = (
             slot_name

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -760,15 +760,17 @@ class FormValidationAction(Action, ABC):
         if also_mapped_in_domain:
             warnings.warn(
                 f"Slot '{slot_name}' is mapped in the domain and your custom "
-                f"action defines '{method_name}'. It is recommended to define a "
-                f"slot mapping in either of both places."
+                f"action defines '{method_name}'. '{method_name}' will override any "
+                f"extractions of the predefined slot mapping from the domain. It is "
+                f"suggested to define a slot mapping in only one of the two ways for "
+                f"clarity."
             )
 
         extracted = await utils.call_potential_coroutine(
             extract_method(dispatcher, tracker, domain)
         )
 
-        if extracted:
+        if isinstance(extracted, dict):
             return [SlotSet(slot, value) for slot, value in extracted.items()]
 
         warnings.warn(
@@ -796,7 +798,7 @@ class FormValidationAction(Action, ABC):
 
         Returns:
             Slot names which should be filled by the form. By default it
-            returns the slot names which are listed for this form in the domain 
+            returns the slot names which are listed for this form in the domain
             and use predefined mappings.
         """
         return slots_mapped_in_domain
@@ -845,7 +847,7 @@ class FormValidationAction(Action, ABC):
                 validate_method(slot_value, dispatcher, tracker, domain)
             )
 
-            if validation_output:
+            if isinstance(validation_output, dict):
                 slots.update(validation_output)
             else:
                 warnings.warn(

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -795,8 +795,9 @@ class FormValidationAction(Action, ABC):
             domain: the bot's domain.
 
         Returns:
-            Slot names which should be filled by the domain. By default it
-            returns the slot names which were mapped in the domain for this form.
+            Slot names which should be filled by the form. By default it
+            returns the slot names which are listed for this form in the domain 
+            and use predefined mappings.
         """
         return slots_mapped_in_domain
 

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -657,8 +657,7 @@ class FormAction(Action):
         return f"FormAction('{self.name()}')"
 
     def _get_entity_type_of_slot_to_fill(
-        self,
-        slot_to_fill: Optional[Text],
+        self, slot_to_fill: Optional[Text],
     ) -> Optional[Text]:
         if not slot_to_fill:
             return None
@@ -708,7 +707,7 @@ class FormValidationAction(Action, ABC):
     ) -> List[EventType]:
         """Extracts custom slots using available `extract_<slot name>` methods.
 
-        Uses the information from `self.missing_slots` to gather which slots should
+        Uses the information from `self.required_slots` to gather which slots should
         be extracted.
 
         Args:
@@ -726,57 +725,90 @@ class FormValidationAction(Action, ABC):
             `SlotSet` for any extracted slots.
         """
         custom_slots = []
-        slots_to_extract = await self.required_slots(dispatcher, tracker, domain)
-
-        if slots_to_extract is None:
-            return []
+        slots_to_extract = await self.required_slots(
+            self.slots_mapped_in_domain(domain), dispatcher, tracker, domain
+        )
 
         for slot_name in slots_to_extract:
-            method_name = f"extract_{slot_name.replace('-', '_')}"
-            extract_method = getattr(self, method_name, None)
-
-            if not extract_method:
-                warnings.warn(
-                    f"No method '{method_name}' found for slot "
-                    f"'{slot_name}'. Skipping extraction for this slot."
-                )
-                continue
-
-            extracted = await utils.call_potential_coroutine(
-                extract_method(dispatcher, tracker, domain)
+            custom_slots += await self._extract_slot(
+                slot_name, dispatcher, tracker, domain
             )
-
-            if extracted:
-                custom_slots += [
-                    SlotSet(slot, value) for slot, value in extracted.items()
-                ]
-            else:
-                warnings.warn(
-                    f"Cannot extract `{slot_name}`: make sure the extract method "
-                    f"returns the correct output."
-                )
-
         return custom_slots
 
-    async def required_slots(
+    async def _extract_slot(
         self,
+        slot_name: Text,
         dispatcher: "CollectingDispatcher",
         tracker: "Tracker",
         domain: "DomainDict",
-    ) -> Optional[List[Text]]:
+    ) -> List[EventType]:
+        method_name = f"extract_{slot_name.replace('-', '_')}"
+        also_mapped_in_domain = slot_name in self.slots_mapped_in_domain(domain)
+        extract_method = getattr(self, method_name, None)
+
+        if not extract_method and not also_mapped_in_domain:
+            warnings.warn(
+                f"No method '{method_name}' found for slot "
+                f"'{slot_name}'. Skipping extraction for this slot."
+            )
+            return []
+
+        if not extract_method:
+            return []
+
+        if also_mapped_in_domain:
+            warnings.warn(
+                f"Slot '{slot_name}' is mapped in the domain and your custom "
+                f"action defines '{method_name}'. It is recommended to define a "
+                f"slot mapping in either of both places."
+            )
+
+        extracted = await utils.call_potential_coroutine(
+            extract_method(dispatcher, tracker, domain)
+        )
+
+        if extracted:
+            return [SlotSet(slot, value) for slot, value in extracted.items()]
+
+        warnings.warn(
+            f"Cannot extract `{slot_name}`: make sure the extract method "
+            f"returns the correct output."
+        )
+        return []
+
+    async def required_slots(
+        self,
+        slots_mapped_in_domain: List[Text],
+        dispatcher: "CollectingDispatcher",
+        tracker: "Tracker",
+        domain: "DomainDict",
+    ) -> List[Text]:
         """Returns slots which the form should fill.
 
         Args:
+            slots_mapped_in_domain: Names of slots of this form which were mapped in
+                the domain.
             dispatcher: the dispatcher which is used to
                 send messages back to the user.
             tracker: the conversation tracker for the current user.
             domain: the bot's domain.
 
         Returns:
-            `None` in case this form doesn't extract any custom slots. Otherwise
-            returns the names of all custom slots which need to be filled.
+            Slot names which should be filled by the domain. By default it
+            returns the slot names which were mapped in the domain for this form.
         """
-        return None
+        return slots_mapped_in_domain
+
+    def slots_mapped_in_domain(self, domain: "DomainDict") -> List[Text]:
+        """Returns slots which were mapped in the domain for the current form.
+
+        Args:
+            domain: The current domain.
+
+        Returns:
+            Slot names mapped in the domain.
+        """
+        return list(domain.get("forms", {}).get(self.name(), {}).keys())
 
     async def validate(
         self,
@@ -796,7 +828,7 @@ class FormValidationAction(Action, ABC):
         """
         slots: Dict[Text, Any] = tracker.slots_to_validate()
 
-        for slot_name, slot_value in list(slots.items()):
+        for slot_name, slot_value in slots.items():
             method_name = f"validate_{slot_name.replace('-','_')}"
             validate_method = getattr(self, method_name, None)
 
@@ -844,57 +876,20 @@ class FormValidationAction(Action, ABC):
             If the `SlotSet` event sets `requested_slot` to `None`, the form will be
             deactivated.
         """
-        required_slots = await self.required_slots(dispatcher, tracker, domain)
-        missing_slots = await self.missing_slots(dispatcher, tracker, domain)
+        required_slots = await self.required_slots(
+            self.slots_mapped_in_domain(domain), dispatcher, tracker, domain
+        )
+        if required_slots and required_slots == self.slots_mapped_in_domain(domain):
+            # If users didn't override `required_slots` then we'll let the `FormAction`
+            # within Rasa Open Source request the next slot.
+            return
 
-        if required_slots is None and not missing_slots:
-            # It seems like `required_slots` wasn't overridden. In this case we
-            # leave the deactivation of the form to the `FormAction` within
-            # Rasa Open Source
-            return None
-
-        missing_slots = await self.missing_slots(dispatcher, tracker, domain)
-        if not missing_slots:
-            # No more missing_slots slots. Form can be deactivated.
-            return SlotSet(REQUESTED_SLOT, None)
-
-        # request next slot
-        return SlotSet(REQUESTED_SLOT, missing_slots[0])
-
-    async def missing_slots(
-        self,
-        dispatcher: "CollectingDispatcher",
-        tracker: "Tracker",
-        domain: "DomainDict",
-    ) -> List[Text]:
-        """Returns slots which still need to be filled.
-
-        Args:
-            dispatcher: the dispatcher which is used to
-                send messages back to the user.
-            tracker: the conversation tracker for the current user.
-            domain: the bot's domain.
-
-        Returns:
-            The slots which aren't already filled.
-        """
-        required_slots = await self.required_slots(dispatcher, tracker, domain)
-        if required_slots is None:
-            return []
-
-        slots_mapped_in_domain = self.slots_mapped_in_domain(domain)
-
-        all_required_slots = required_slots + [
-            domain_slot
-            for domain_slot in slots_mapped_in_domain
-            if domain_slot not in required_slots
-        ]
-
-        return [
+        missing_slots = (
             slot_name
-            for slot_name in all_required_slots
-            if not tracker.slots.get(slot_name)
-        ]
+            for slot_name in await self.required_slots(
+                self.slots_mapped_in_domain(domain), dispatcher, tracker, domain
+            )
+            if tracker.slots.get(slot_name) is None
+        )
 
-    def slots_mapped_in_domain(self, domain: "DomainDict") -> List[Text]:
-        return list(domain.get("forms", {}).get(self.name(), {}).keys())
+        return SlotSet(REQUESTED_SLOT, next(missing_slots, None))

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1707,7 +1707,7 @@ async def test_extract_and_validate_slot(
 
         async def required_slots(
             self,
-            slot_mapped_in_domain: List[Text],
+            slots_mapped_in_domain: List[Text],
             dispatcher: "CollectingDispatcher",
             tracker: "Tracker",
             domain: "DomainDict",
@@ -1765,7 +1765,7 @@ async def test_extract_slot_only():
 
         async def required_slots(
             self,
-            slot_mapped_in_domain: List[Text],
+            slots_mapped_in_domain: List[Text],
             dispatcher: "CollectingDispatcher",
             tracker: "Tracker",
             domain: "DomainDict",
@@ -1824,7 +1824,7 @@ async def test_warning_for_slot_extractions(
 
         async def required_slots(
             self,
-            slot_mapped_in_domain: List[Text],
+            slots_mapped_in_domain: List[Text],
             dispatcher: "CollectingDispatcher",
             tracker: "Tracker",
             domain: "DomainDict",

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1866,7 +1866,11 @@ async def test_warning_for_slot_extractions(
         # No domain slots, no custom slots
         ([], {}, [SlotSet(REQUESTED_SLOT, None)]),
         # Custom slot - no domain slots
-        (["some value"], {}, [SlotSet(REQUESTED_SLOT, "some value")],),
+        (
+            ["some value"],
+            {},
+            [SlotSet(REQUESTED_SLOT, "some value")],
+        ),
         # Domain slots are ignored in overridden `required_slots`
         (
             [],
@@ -1874,7 +1878,11 @@ async def test_warning_for_slot_extractions(
             [SlotSet(REQUESTED_SLOT, None)],
         ),
         # `required_slots` was not overridden - Rasa Open Source will request next slot.
-        (["another_slot"], {"forms": {"some_form": {"another_slot": []}}}, [],),
+        (
+            ["another_slot"],
+            {"forms": {"some_form": {"another_slot": []}}},
+            [],
+        ),
     ],
 )
 async def test_ask_for_next_slot(

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1502,8 +1502,11 @@ def test_form_deprecation():
 
 
 class TestFormValidationAction(FormValidationAction):
+    def __init__(self, form_name: Text = "some_form") -> None:
+        self.form_name = form_name
+
     def name(self) -> Text:
-        return "some_form"
+        return self.form_name
 
     def validate_slot1(
         self,
@@ -1550,7 +1553,8 @@ class TestFormValidationAction(FormValidationAction):
 
 
 async def test_form_validation_action():
-    form = TestFormValidationAction()
+    form_name = "test_form_validation_action"
+    form = TestFormValidationAction(form_name)
 
     # tracker with active form
     tracker = Tracker(
@@ -1560,12 +1564,19 @@ async def test_form_validation_action():
         [SlotSet("slot1", "correct_value"), SlotSet("slot2", "incorrect_value")],
         False,
         None,
-        {"name": "some_form", "is_interrupted": False, "rejected": False},
+        {"name": form_name, "is_interrupted": False, "rejected": False},
         "action_listen",
     )
 
     dispatcher = CollectingDispatcher()
-    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain={})
+    with pytest.warns(None) as warnings:
+        events = await form.run(
+            dispatcher=dispatcher,
+            tracker=tracker,
+            domain={"forms": {form_name: {"slot1": [], "slot2": []}}},
+        )
+
+    assert not warnings
     assert events == [
         SlotSet("slot2", None),
         SlotSet("slot1", "validated_value"),
@@ -1573,6 +1584,7 @@ async def test_form_validation_action():
 
 
 async def test_form_validation_action_async():
+    form_name = "some_form"
     form = TestFormValidationAction()
 
     # tracker with active form
@@ -1583,16 +1595,21 @@ async def test_form_validation_action_async():
         [SlotSet("slot3", "correct_value")],
         False,
         None,
-        {"name": "some_form", "is_interrupted": False, "rejected": False},
+        {"name": form_name, "is_interrupted": False, "rejected": False},
         "action_listen",
     )
 
     dispatcher = CollectingDispatcher()
-    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain={})
+    events = await form.run(
+        dispatcher=dispatcher,
+        tracker=tracker,
+        domain={"forms": {form_name: {"slot1": [], "slot3": []}}},
+    )
     assert events == [SlotSet("slot3", "validated_value")]
 
 
 async def test_form_validation_without_validate_function():
+    form_name = "some_form"
     form = TestFormValidationAction()
 
     # tracker with active form
@@ -1607,24 +1624,31 @@ async def test_form_validation_without_validate_function():
         ],
         False,
         None,
-        {"name": "some_form", "is_interrupted": False, "rejected": False},
+        {"name": form_name, "is_interrupted": False, "rejected": False},
         "action_listen",
     )
 
     dispatcher = CollectingDispatcher()
     with pytest.warns(UserWarning):
-        events = await form.run(dispatcher=dispatcher, tracker=tracker, domain={})
-        assert events == [
-            SlotSet("slot3", "some_value"),
-            SlotSet("slot2", None),
-            SlotSet("slot1", "validated_value"),
-        ]
+        events = await form.run(
+            dispatcher=dispatcher,
+            tracker=tracker,
+            domain={"forms": {form_name: {"slot1": [], "slot2": [], "slot3": []}}},
+        )
+
+    assert events == [
+        SlotSet("slot3", "some_value"),
+        SlotSet("slot2", None),
+        SlotSet("slot1", "validated_value"),
+    ]
 
 
 async def test_form_validation_dash_slot():
+    form_name = "some_form"
+
     class TestFormValidationDashSlotAction(FormValidationAction):
         def name(self) -> Text:
-            return "some_form"
+            return form_name
 
         def validate_slot_with_dash(
             self,
@@ -1651,12 +1675,16 @@ async def test_form_validation_dash_slot():
         [SlotSet("slot-with-dash", "correct_value")],
         False,
         None,
-        {"name": "some_form", "is_interrupted": False, "rejected": False},
+        {"name": form_name, "is_interrupted": False, "rejected": False},
         "action_listen",
     )
 
     dispatcher = CollectingDispatcher()
-    events = await form.run(dispatcher=dispatcher, tracker=tracker, domain={})
+    events = await form.run(
+        dispatcher=dispatcher,
+        tracker=tracker,
+        domain={"forms": {form_name: {"slot-with-dash": []}}},
+    )
     assert events == [
         SlotSet("slot-with-dash", "validated_value"),
     ]
@@ -1679,6 +1707,7 @@ async def test_extract_and_validate_slot(
 
         async def required_slots(
             self,
+            slot_mapped_in_domain: List[Text],
             dispatcher: "CollectingDispatcher",
             tracker: "Tracker",
             domain: "DomainDict",
@@ -1736,6 +1765,7 @@ async def test_extract_slot_only():
 
         async def required_slots(
             self,
+            slot_mapped_in_domain: List[Text],
             dispatcher: "CollectingDispatcher",
             tracker: "Tracker",
             domain: "DomainDict",
@@ -1774,24 +1804,81 @@ async def test_extract_slot_only():
 
 
 @pytest.mark.parametrize(
+    "required_slots, domain, next_slot_events",
+    [
+        # Custom slot mapping but no `extract` method
+        (["my_slot", "other_slot"], {}, [SlotSet(REQUESTED_SLOT, "other_slot")]),
+        # Extract method for slot which is also mapped in domain
+        (["my_slot"], {"forms": {"some_form": {"my_slot": []}}}, []),
+    ],
+)
+async def test_warning_for_slot_extractions(
+    required_slots: List[Text], domain: DomainDict, next_slot_events: List[EventType]
+):
+    custom_slot = "my_slot"
+    unvalidated_value = "some value"
+
+    class TestFormValidationWithCustomSlots(FormValidationAction):
+        def name(self) -> Text:
+            return "some_form"
+
+        async def required_slots(
+            self,
+            slot_mapped_in_domain: List[Text],
+            dispatcher: "CollectingDispatcher",
+            tracker: "Tracker",
+            domain: "DomainDict",
+        ) -> List[Text]:
+            return required_slots
+
+        async def extract_my_slot(
+            self,
+            dispatcher: "CollectingDispatcher",
+            tracker: "Tracker",
+            domain: "DomainDict",
+        ) -> Dict[Text, Any]:
+            return {custom_slot: unvalidated_value}
+
+    form = TestFormValidationWithCustomSlots()
+
+    # tracker with active form
+    tracker = Tracker(
+        "default",
+        {},
+        {},
+        [],
+        False,
+        None,
+        {"name": "some_form", "is_interrupted": False, "rejected": False},
+        "action_listen",
+    )
+
+    dispatcher = CollectingDispatcher()
+    with pytest.warns(UserWarning):
+        events = await form.run(dispatcher=dispatcher, tracker=tracker, domain=domain)
+
+    assert events == [SlotSet(custom_slot, unvalidated_value), *next_slot_events]
+
+
+@pytest.mark.parametrize(
     "custom_slots, domain, expected_return_events",
     [
-        (None, {}, []),
+        # No domain slots, no custom slots
         ([], {}, [SlotSet(REQUESTED_SLOT, None)]),
-        (
-            ["some value"],
-            {},
-            [SlotSet(REQUESTED_SLOT, "some value")],
-        ),
+        # Custom slot - no domain slots
+        (["some value"], {}, [SlotSet(REQUESTED_SLOT, "some value")],),
+        # Domain slots are ignored in overridden `required_slots`
         (
             [],
             {"forms": {"some_form": {"another_slot": []}}},
-            [SlotSet(REQUESTED_SLOT, "another_slot")],
+            [SlotSet(REQUESTED_SLOT, None)],
         ),
+        # `required_slots` was not overridden - Rasa Open Source will request next slot.
+        (["another_slot"], {"forms": {"some_form": {"another_slot": []}}}, [],),
     ],
 )
 async def test_ask_for_next_slot(
-    custom_slots: Optional[List[Text]],
+    custom_slots: List[Text],
     domain: Dict,
     expected_return_events: List[EventType],
 ):
@@ -1801,10 +1888,11 @@ async def test_ask_for_next_slot(
 
         async def required_slots(
             self,
+            slots_mapped_in_domain: List[Text],
             dispatcher: "CollectingDispatcher",
             tracker: "Tracker",
             domain: "DomainDict",
-        ) -> Optional[List[Text]]:
+        ) -> List[Text]:
             return custom_slots
 
     form = TestFormRequestSlot()


### PR DESCRIPTION
**Proposed changes**:
- follow up of https://github.com/RasaHQ/rasa/pull/7233 and https://github.com/RasaHQ/rasa-sdk/pull/329
- `required_slots` receive the slots which were mapped in the domain as parameter to make it explicit for users that this is something which `required_slots` should return
- warn if a slot was mapped in the domain and has an additional custom mapping within the SDK.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
