### PR TITLE
7078/intent_from_fallback_helper

### DIFF
--- a/changelog/7078.improvement.md
+++ b/changelog/7078.improvement.md
@@ -1,0 +1,2 @@
+Adds the method `get_intent_of_latest_message` to the `Tracker` allowing easier 
+access to the user's latest intent in case of an `nlu_fallback`. 

--- a/docs/docs/sdk-tracker.mdx
+++ b/docs/docs/sdk-tracker.mdx
@@ -119,3 +119,21 @@ Return a list of events after the most recent restart.
   * **Return type**
 
   `Optional[Any]`
+
+### Tracker.get_intent_of_latest_message
+
+  Retrieves the user's latest intent.
+
+  * **Parameters**
+
+    * `skip_fallback_intent` (default: `True`) – Optionally skip the `nlu_fallback` intent and return the next highest ranked.
+
+
+  * **Returns**
+
+  The intent of the latest message if available.
+
+
+  * **Return type**
+
+  `Optional[Text]`

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -289,9 +289,9 @@ class Tracker:
         if not intent_ranking:
             return None
 
-        highest_randing_intent = intent_ranking[0]
+        highest_ranking_intent = intent_ranking[0]
         if (
-            highest_randing_intent["name"] == NLU_FALLBACK_INTENT_NAME
+            highest_ranking_intent["name"] == NLU_FALLBACK_INTENT_NAME
             and skip_fallback_intent
         ):
             if len(intent_ranking) >= 2:
@@ -299,7 +299,7 @@ class Tracker:
             else:
                 return None
         else:
-            return highest_randing_intent["name"]
+            return highest_ranking_intent["name"]
 
 
 class Action:

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -280,6 +280,9 @@ class Tracker:
         Args:
             skip_fallback_intent: Optionally skip the nlu_fallback intent
                 and return the next.
+
+        Returns:
+            Intent of latest message if available.
         """
         latest_message = self.latest_message
         if not latest_message:

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -7,7 +7,7 @@ from rasa_sdk.events import (
     SlotSet,
     Restarted,
 )
-from rasa_sdk.interfaces import ACTION_LISTEN_NAME
+from rasa_sdk.interfaces import ACTION_LISTEN_NAME, NLU_FALLBACK_INTENT_NAME
 from typing import List, Dict, Text, Any
 
 
@@ -141,7 +141,7 @@ def test_get_intent_of_latest_message_with_missing_data():
     assert not tracker.get_intent_of_latest_message()
 
     tracker.latest_message = {
-        "intent": {"name": "nlu_fallback", "confidence": 0.9},
+        "intent": {"name": NLU_FALLBACK_INTENT_NAME, "confidence": 0.9},
     }
     assert not tracker.get_intent_of_latest_message()
 
@@ -149,22 +149,22 @@ def test_get_intent_of_latest_message_with_missing_data():
 def test_get_intent_of_latest_message_with_only_fallback():
     tracker = get_tracker([])
     tracker.latest_message = {
-        "intent": {"name": "nlu_fallback", "confidence": 0.9},
-        "intent_ranking": [{"name": "nlu_fallback", "confidence": 0.9}],
+        "intent": {"name": NLU_FALLBACK_INTENT_NAME, "confidence": 0.9},
+        "intent_ranking": [{"name": NLU_FALLBACK_INTENT_NAME, "confidence": 0.9}],
     }
     assert not tracker.get_intent_of_latest_message()
     assert (
         tracker.get_intent_of_latest_message(skip_fallback_intent=False)
-        == "nlu_fallback"
+        == NLU_FALLBACK_INTENT_NAME
     )
 
 
 def test_get_intent_of_latest_message_with_user_intent():
     tracker = get_tracker([])
     tracker.latest_message = {
-        "intent": {"name": "nlu_fallback", "confidence": 0.9},
+        "intent": {"name": NLU_FALLBACK_INTENT_NAME, "confidence": 0.9},
         "intent_ranking": [
-            {"name": "nlu_fallback", "confidence": 0.9},
+            {"name": NLU_FALLBACK_INTENT_NAME, "confidence": 0.9},
             {"name": "hello", "confidence": 0.8},
             {"name": "goodbye", "confidence": 0.7},
         ],
@@ -172,5 +172,5 @@ def test_get_intent_of_latest_message_with_user_intent():
     assert tracker.get_intent_of_latest_message() == "hello"
     assert (
         tracker.get_intent_of_latest_message(skip_fallback_intent=False)
-        == "nlu_fallback"
+        == NLU_FALLBACK_INTENT_NAME
     )


### PR DESCRIPTION
#7078 Add a helper method to rasa-sdk for getting the next most likely user intent in case of nlu fallback.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
