### PR TITLE
Slots mapped in domain

### DIFF
--- a/changelog/344.bugfix.md
+++ b/changelog/344.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug in the `FormValidationAction` which immediately deactivated the form.

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -834,7 +834,7 @@ class FormValidationAction(Action, ABC):
         """
         slots: Dict[Text, Any] = tracker.slots_to_validate()
 
-        for slot_name, slot_value in slots.items():
+        for slot_name, slot_value in list(slots.items()):
             method_name = f"validate_{slot_name.replace('-','_')}"
             validate_method = getattr(self, method_name, None)
 

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -681,6 +681,9 @@ class FormAction(Action):
 class FormValidationAction(Action, ABC):
     """A helper class for slot validations and extractions of custom slots."""
 
+    def form_name(self) -> Text:
+        return self.name().replace("validate_", "", 1)
+
     async def run(
         self,
         dispatcher: "CollectingDispatcher",
@@ -812,9 +815,7 @@ class FormValidationAction(Action, ABC):
         Returns:
             Slot names mapped in the domain.
         """
-        return list(
-            domain.get("forms", {}).get(self.name().strip("validate_"), {}).keys()
-        )
+        return list(domain.get("forms", {}).get(self.form_name(), {}).keys())
 
     async def validate(
         self,

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -682,6 +682,7 @@ class FormValidationAction(Action, ABC):
     """A helper class for slot validations and extractions of custom slots."""
 
     def form_name(self) -> Text:
+        """Returns the form's name."""
         return self.name().replace("validate_", "", 1)
 
     async def run(
@@ -690,6 +691,7 @@ class FormValidationAction(Action, ABC):
         tracker: "Tracker",
         domain: "DomainDict",
     ) -> List[EventType]:
+        """Runs the custom actions. Please the docstring of the parent class."""
         extraction_events = await self.extract_custom_slots(dispatcher, tracker, domain)
         tracker.add_slots(extraction_events)
 

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -812,7 +812,9 @@ class FormValidationAction(Action, ABC):
         Returns:
             Slot names mapped in the domain.
         """
-        return list(domain.get("forms", {}).get(self.name(), {}).keys())
+        return list(
+            domain.get("forms", {}).get(self.name().strip("validate_"), {}).keys()
+        )
 
     async def validate(
         self,


### PR DESCRIPTION
**Proposed changes**:
- (https://github.com/RasaHQ/rasa-sdk/issues/344)  Fix slots_mapped_in_domain, by stripping `validate_` from the name to get the form name
- Fix loop by first making a list out of slots.items, because during the loop slots can change.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
