### PR TITLE
Remove README.md from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@ docs/*
 .github/*
 tests/*
 .gitignore
-README.md
 Dockerfile
 CHANGELOG.txt
 .pre-commit-config.yaml


### PR DESCRIPTION
**Proposed changes**:
- the README.md file is required to build a Docker image

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
