### PR TITLE
fix pycodestyle for forks

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -64,7 +64,7 @@ jobs:
 
         # Fetch entire history for current branch so that `make lint-docstrings`
         # can calculate the proper diff between the branches
-        git pull --ff-only --unshallow origin "${{ github.head_ref }}"
+        git pull --ff-only --unshallow origin "${{ github.ref }}"
 
     - name: Lint Code 🎎
       run: |

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -64,7 +64,7 @@ jobs:
 
         # Fetch entire history for current branch so that `make lint-docstrings`
         # can calculate the proper diff between the branches
-        git pull --ff-only --unshallow origin "${{ github.ref }}"
+        git fetch --unshallow origin "${{ github.ref }}"
 
     - name: Lint Code 🎎
       run: |

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -55,8 +55,6 @@ def create_argument_parser():
     utils.add_logging_option_arguments(parser)
     return parser
 
-def test_without_docstring():
-    print("bla")
 
 def create_app(
     action_package_name: Union[Text, types.ModuleType],

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -56,10 +56,6 @@ def create_argument_parser():
     return parser
 
 
-def function_without_docstring():
-    print("I don't have a docstring")
-
-
 def create_app(
     action_package_name: Union[Text, types.ModuleType],
     cors_origins: Union[Text, List[Text], None] = "*",

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -55,6 +55,8 @@ def create_argument_parser():
     utils.add_logging_option_arguments(parser)
     return parser
 
+def test_without_docstring():
+    print("bla")
 
 def create_app(
     action_package_name: Union[Text, types.ModuleType],

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -56,6 +56,10 @@ def create_argument_parser():
     return parser
 
 
+def function_without_docstring():
+    print("I don't have a docstring")
+
+
 def create_app(
     action_package_name: Union[Text, types.ModuleType],
     cors_origins: Union[Text, List[Text], None] = "*",


### PR DESCRIPTION
**Proposed changes**:
- fix pycodestyle linting for forks
- previously this error happened during `Checkout target branch to be able to diff`
  ```
  Run git fetch origin "master"
  From https://github.com/RasaHQ/rasa-sdk
  * branch            master     -> FETCH_HEAD
  * [new branch]      master     -> origin/master
  fatal: couldn't find remote ref logging-file-for-action
  Error: Process completed with exit code 1.
  ```
- you can see the previous CI run for a test

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
