### PR TITLE
Skip publishing changelog for alphas or RCs

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -162,24 +162,8 @@ jobs:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}
 
-    - name: Check if tag version is official release
-      # We need this to avoid attempting to publish changelogs for alphas / rcs
-      id: rasa_sdk_get_version
-      if: env.IS_TAG_BUILD == 'true'
-      env:
-        GITHUB_TAG: ${{ github.ref }}
-      run: |
-        CURRENT_TAG=${GITHUB_TAG/refs\/tags\//}
-
-        # Avoid that the script gets released for alphas or release candidates
-        if [[ "$CURRENT_TAG" =~ ^[0-9.]+$ ]]; then
-          echo "::set-output name=is_official_version::true"
-        else
-          echo "::set-output name=is_official_version::false"
-        fi
-
     - name: Publish Release Notes 🗞
-      if: env.IS_TAG_BUILD && steps.rasa_sdk_get_version.outputs.is_official_version == 'true'
+      if: env.IS_TAG_BUILD
       env:
         GITHUB_TAG: ${{ github.ref }}
         GITHUB_REPO_SLUG: ${{ github.repository }}

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -172,7 +172,7 @@ jobs:
         CURRENT_TAG=${GITHUB_TAG/refs\/tags\//}
 
         # Avoid that the script gets released for alphas or release candidates
-        if [[ "$CURRENT_TAG" =~ "^[0-9.]+$" ]]; then
+        if [[ "$CURRENT_TAG" =~ ^[0-9.]+$ ]]; then
           echo "::set-output name=is_official_version::true"
         else
           echo "::set-output name=is_official_version::false"

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -162,8 +162,24 @@ jobs:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}
 
+    - name: Check if tag version is official release
+      # We need this to avoid attempting to publish changelogs for alphas / rcs
+      id: rasa_sdk_get_version
+      if: env.IS_TAG_BUILD == 'true'
+      env:
+        GITHUB_TAG: ${{ github.ref }}
+      run: |
+        CURRENT_TAG=${GITHUB_TAG/refs\/tags\//}
+
+        # Avoid that the script gets released for alphas or release candidates
+        if [[ "$CURRENT_TAG" =~ "^[0-9.]+$" ]]; then
+          echo "::set-output name=is_official_version::true"
+        else
+          echo "::set-output name=is_official_version::false"
+        fi
+
     - name: Publish Release Notes 🗞
-      if: env.IS_TAG_BUILD
+      if: env.IS_TAG_BUILD && steps.rasa_sdk_get_version.outputs.is_official_version == 'true'
       env:
         GITHUB_TAG: ${{ github.ref }}
         GITHUB_REPO_SLUG: ${{ github.repository }}

--- a/scripts/publish_gh_release_notes.py
+++ b/scripts/publish_gh_release_notes.py
@@ -23,6 +23,7 @@ from typing import Text
 
 # if this needs any more dependencies, they need to be installed on github deploy stage
 import github3
+from pep440_version_utils import Version
 
 def create_github_release(slug: Text, token: Text, tag_name: Text, body: Text):
     """Create a github release."""
@@ -75,7 +76,11 @@ def main():
         print("GITHUB_REPO_SLUG not set", file=sys.stderr)
         return 1
 
-    md_body = parse_changelog(tag_name)
+    version = Version(tag_name)
+    if version.pre:
+        md_body = "_Pre-release version_"
+    else:
+        md_body = parse_changelog(tag_name)
 
     if not md_body:
         print("Failed to extract changelog entries for version from changelog.")


### PR DESCRIPTION
**Proposed changes**:
- Fixes #360 
- @m-vdb I am not 100% sure this is the best way to skip the changelogs, I tried to harmonize the `continuous-integration.yml` with what we have in `rasa-x`. Do let me know if there's a better way to do this / if I'm missing something! 🙏  

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
