### PR TITLE
Rename occurrences of "master" to "main"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,5 @@
 - [ ] made PR ready for code review
 - [ ] added some tests for the functionality
 - [ ] updated the documentation
-- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
+- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
 - [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -3,7 +3,7 @@ name: Continous Integration
 on:
   push:
     branches:
-    - master
+    - main
     tags:
     - '*'
   pull_request:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: Publish Documentation
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
     tags:
     - '**'
 
@@ -20,7 +20,7 @@ jobs:
   docs:
     name: Build Docs
     runs-on: ubuntu-latest
-    if: github.repository == 'RasaHQ/rasa-sdk'  # don't run this for master branches of forks, would fail anyways
+    if: github.repository == 'RasaHQ/rasa-sdk'  # don't run this for main branches of forks, would fail anyways
 
     steps:
     - name: Checkout git repository 🕝

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -8,7 +8,7 @@ jobs:
   cleanup_runs:
     name: Cancel old branch builds
     runs-on: ubuntu-latest
-    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
 
     steps:
       - name: Find and cancel old builds of this branch

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -3,7 +3,7 @@ name: Typo CI
 on:
   push:
     branches-ignore:
-      - master
+      - main
 jobs:
   spellcheck:
     name: Typo CI (GitHub Action)

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ lint:
 	poetry run black --check rasa_sdk tests
 	make lint-docstrings
 
- # Compare against `master` if no branch was provided
-BRANCH ?= master
+ # Compare against `main` if no branch was provided
+BRANCH ?= main
 lint-docstrings:
 # Lint docstrings only against the the diff to avoid too many errors.
 # Check only production code. Ignore other flake errors which are captured by `lint`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rasa Python-SDK
 [![Join the chat on Rasa Community Forum](https://img.shields.io/badge/forum-join%20discussions-brightgreen.svg)](https://forum.rasa.com/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://github.com/RasaHQ/rasa-sdk/workflows/Continous%20Integration/badge.svg?event=push)](https://github.com/RasaHQ/rasa-sdk/actions/runs/)
-[![Coverage Status](https://coveralls.io/repos/github/RasaHQ/rasa-sdk/badge.svg?branch=master)](https://coveralls.io/github/RasaHQ/rasa-sdk?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/RasaHQ/rasa-sdk/badge.svg?branch=main)](https://coveralls.io/github/RasaHQ/rasa-sdk?branch=main)
 [![PyPI version](https://img.shields.io/pypi/v/rasa-sdk.svg)](https://pypi.python.org/pypi/rasa-sdk)
 [![Documentation Status](https://img.shields.io/badge/docs-stable-brightgreen.svg)](https://rasa.com/docs)
 
@@ -116,12 +116,12 @@ Releasing a new version is quite simple, as the packages are build and distribut
 by GitHub Actions.
 
 *Release steps*:
-1. Switch to the branch you want to cut the release from (`master` in case of a 
+1. Switch to the branch you want to cut the release from (`main` in case of a 
   major / minor, the current release branch for patch releases).
 2. Run `make release`
-3. Create a PR against master or the release branch (e.g. `1.2.x`)
+3. Create a PR against main or the release branch (e.g. `1.2.x`)
 4. Once your PR is merged, tag a new release (this SHOULD always happen on 
-  master or release branches), e.g. using
+  `main` or release branches), e.g. using
     ```bash
     git tag 1.2.0 -m "next release"
     git push origin 1.2.0

--- a/docs/docs/knowledge-base-actions.mdx
+++ b/docs/docs/knowledge-base-actions.mdx
@@ -471,7 +471,7 @@ Furthermore, resolving any mention to the last mentioned object in the conversat
 
 If you want to tackle more complex use cases, you can write your own custom action.
 We added some helper functions to `rasa_sdk.knowledge_base.utils`
-([link to code](https://github.com/RasaHQ/rasa-sdk/tree/master/rasa_sdk/knowledge_base/) )
+([link to code](https://github.com/RasaHQ/rasa-sdk/tree/main/rasa_sdk/knowledge_base/) )
 to help you when implement your own solution.
 We recommend using `KnowledgeBase` interface so that you can still use the `ActionQueryKnowledgeBase`
 alongside your new custom action.
@@ -548,7 +548,7 @@ See the [example bot](https://github.com/RasaHQ/rasa/blob/master/examples/knowle
 example implementation of an `InMemoryKnowledgeBase` that uses the method `set_representation_function_of_object()`
 to overwrite the default representation of the object type “hotel.”
 The implementation of the `InMemoryKnowledgeBase` itself can be found in the
-[rasa-sdk](https://github.com/RasaHQ/rasa-sdk/tree/master/rasa_sdk/knowledge_base/) package.
+[rasa-sdk](https://github.com/RasaHQ/rasa-sdk/tree/main/rasa_sdk/knowledge_base/) package.
 
 <a aria-hidden="true" tabIndex="-1" className="anchor enhancedAnchor" id="custom-knowledge-base"></a>
 
@@ -557,7 +557,7 @@ The implementation of the `InMemoryKnowledgeBase` itself can be found in the
 If you have more data or if you want to use a more complex data structure that, for example, involves relations between
 different objects, you can create your own knowledge base implementation.
 Just inherit `KnowledgeBase` and implement the methods `get_objects()`, `get_object()`, and
-`get_attributes_of_object()`. The [knowledge base code](https://github.com/RasaHQ/rasa-sdk/tree/master/rasa_sdk/knowledge_base/)
+`get_attributes_of_object()`. The [knowledge base code](https://github.com/RasaHQ/rasa-sdk/tree/main/rasa_sdk/knowledge_base/)
 provides more information on what those methods should do.
 
 You can also customize your knowledge base further, by adapting the methods mentioned in the section

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -17,7 +17,7 @@ const RASA_OPEN_SOURCE_SWAP_URL = isDev ? 'http://localhost:3000' : SITE_URL;
 const RASA_X_SWAP_URL = isDev ? 'http://localhost:3001' : SITE_URL;
 
 const versionLabels = {
-  current: 'Master/Unreleased'
+  current: 'Main/Unreleased'
 };
 
 module.exports = {
@@ -126,7 +126,7 @@ module.exports = {
       // https://v2.docusaurus.io/docs/next/docs-introduction/#docs-only-mode
       routeBasePath: '/',
       sidebarPath: require.resolve('./sidebars.js'),
-      editUrl: 'https://github.com/rasahq/rasa-sdk/edit/master/docs/',
+      editUrl: 'https://github.com/rasahq/rasa-sdk/edit/main/docs/',
       showLastUpdateTime: true,
       showLastUpdateAuthor: true,
       rehypePlugins: [

--- a/docs/plugins/program_output.js
+++ b/docs/plugins/program_output.js
@@ -13,7 +13,7 @@
     Caveat: this plugin operates at 2 separate points in time:
         1. During the "pre-build" phase, pre-generating files inside the
            sources/ folder. This phase is run on the "main" version of the repo
-           (master branch, release branches, tags, etc...), which doesn't have
+           (main branch, release branches, tags, etc...), which doesn't have
            several versions of the docs site. This is why `getProgramOutputs()` is
            version-agnostic and simply outputs files in `mainSourceDir`.
         2. At the build phase, happening on the `documentation` branch. In this context,

--- a/scripts/push_docs_to_branch.sh
+++ b/scripts/push_docs_to_branch.sh
@@ -6,15 +6,15 @@ TODAY=`date "+%Y%m%d"`
 # we build new versions only for minors and majors
 PATTERN_FOR_NEW_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.0$"
 PATTERN_FOR_PATCH_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.[1-9]+$"
-MASTER_REF=refs/heads/master
+MAIN_REF=refs/heads/main
 VARIABLES_JSON=docs/docs/variables.json
 SOURCES_FILES=docs/docs/sources/
 CHANGELOG=docs/docs/changelog.mdx
 
 [[ ! $GITHUB_REF =~ $PATTERN_FOR_NEW_VERSION ]] \
 && [[ ! $GITHUB_REF =~ $PATTERN_FOR_PATCH_VERSION ]] \
-&& [[ $GITHUB_REF != $MASTER_REF ]] \
-&& echo "Not on master or tagged version, skipping." \
+&& [[ $GITHUB_REF != $MAIN_REF ]] \
+&& echo "Not on main or tagged version, skipping." \
 && exit 0
 
 NEW_VERSION=

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -186,17 +186,17 @@ def git_current_branch() -> Text:
         return output.decode().strip()
     except CalledProcessError:
         # e.g. we are in detached head state
-        return "master"
+        return "main"
 
 
-def git_current_branch_is_master_or_release() -> bool:
+def git_current_branch_is_main_or_release() -> bool:
     """
     Returns True if the current local git
-    branch is master or a release branch e.g. 1.10.x
+    branch is main or a release branch e.g. 1.10.x
     """
     current_branch = git_current_branch()
     return (
-        current_branch == "master"
+        current_branch == "main"
         or RELEASE_BRANCH_PATTERN.match(current_branch) is not None
     )
 
@@ -302,7 +302,7 @@ def main(args: argparse.Namespace) -> None:
         generate_changelog(version)
 
     # alpha workflow on feature branch when a version bump is required
-    if version.is_alpha and not git_current_branch_is_master_or_release():
+    if version.is_alpha and not git_current_branch_is_main_or_release():
         create_commit(version)
         push_changes()
 


### PR DESCRIPTION
Relates to https://github.com/RasaHQ/rasa/issues/6028

**Proposed changes**:
- Rename occurrences of `master` in the repository
- Some occurrences of `master` deal with other repositories outside of our control, so we can't change them.
- There are some occurrences of `RasaHQ/rasa@master` that should be addressed after we make the change in the Rasa repository
- When this PR is ready for merging, we should:
  - [x] Make an announcement on Slack
  - [x] Rename the `master` branch to `main` in the repo configuration [here](https://github.com/RasaHQ/rasa-sdk/settings/branches)
  - [ ] Merge this PR

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/master/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
