### PR TITLE
rename links to Rasa default branch

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -13,7 +13,7 @@ file is managed by ``towncrier``.
 
 You **may** edit previous change logs to fix problems like typo corrections or such.
 You can find more information on how to add a new change log entry at
-https://github.com/RasaHQ/rasa/tree/master/changelog/ . -->
+https://github.com/RasaHQ/rasa/tree/main/changelog/ . -->
 
 <!-- TOWNCRIER -->
 

--- a/docs/docs/knowledge-base-actions.mdx
+++ b/docs/docs/knowledge-base-actions.mdx
@@ -35,7 +35,7 @@ custom action that inherits from `ActionQueryKnowledgeBase`, a pre-written custo
 the logic to query a knowledge base for objects and their attributes.
 
 You can find a complete example in `examples/knowledgebasebot`
-([knowledge base bot](https://github.com/RasaHQ/rasa/tree/master/examples/knowledgebasebot/)), as well as instructions
+([knowledge base bot](https://github.com/RasaHQ/rasa/tree/main/examples/knowledgebasebot/)), as well as instructions
 for implementing this custom action below.
 
 ## Using `ActionQueryKnowledgeBase`
@@ -544,7 +544,7 @@ You can customize your `InMemoryKnowledgeBase` by overwriting the following func
   You can overwrite it by calling the function `set_ordinal_mention_mapping()`.
   If you want to learn more about how this mapping is used, check out [Resolve Mentions](./knowledge-base-actions.mdx#resolve-mentions).
 
-See the [example bot](https://github.com/RasaHQ/rasa/blob/master/examples/knowledgebasebot/actions/actions.py) for an
+See the [example bot](https://github.com/RasaHQ/rasa/blob/main/examples/knowledgebasebot/actions/actions.py) for an
 example implementation of an `InMemoryKnowledgeBase` that uses the method `set_representation_function_of_object()`
 to overwrite the default representation of the object type “hotel.”
 The implementation of the `InMemoryKnowledgeBase` itself can be found in the


### PR DESCRIPTION
**Proposed changes**:
- Rename references to Rasa Open Source default branch
- Needs to wait for https://github.com/RasaHQ/rasa/pull/7742 to be merged

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
