### PR TITLE
fix regex pattern to match all new micro versions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -66,7 +66,7 @@ jobs:
       run: make install install-docs
 
     - name: Pre-build Docs 🧶
-      run: cd $DOCS_FOLDER && poetry run yarn pre-build
+      run: make prepare-docs
 
     - name: Set up SSH key for cloning / pushing docs
       uses: webfactory/ssh-agent@v0.4.1

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,11 @@ cleanup-generated-changelog:
 	git ls-files --deleted | xargs git checkout
 	git checkout CHANGELOG.mdx
 
-docs:
-	cd docs/ && poetry run yarn pre-build && yarn build
+prepare-docs:
+	cd docs/ && poetry run yarn pre-build
+
+docs: prepare-docs
+	cd docs/ && yarn build
 
 test-docs: generate-pending-changelog docs
 

--- a/scripts/push_docs_to_branch.sh
+++ b/scripts/push_docs_to_branch.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 TODAY=`date "+%Y%m%d"`
 # we build new versions only for minors and majors
 PATTERN_FOR_NEW_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.0$"
-PATTERN_FOR_PATCH_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.[1-9]+$"
+PATTERN_FOR_PATCH_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.[1-9]+[0-9]*$"
 MAIN_REF=refs/heads/main
 VARIABLES_JSON=docs/docs/variables.json
 SOURCES_FILES=docs/docs/sources/

--- a/scripts/push_docs_to_branch.sh
+++ b/scripts/push_docs_to_branch.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
 
+# In case this script fails in our CI workflows, you can run it locally.
+# For instance, if the doc version for 2.2.10 fails to be pushed, you
+# can do:
+#
+# 1. make install install-docs
+# 2. make prepare-docs
+# 3. TMP_DOCS_FOLDER=/tmp/documentation DOCS_BRANCH=documentation GITHUB_REF=refs/tags/2.2.10 GITHUB_REPOSITORY=RasaHQ/rasa-sdk ./scripts/push_docs_to_branch.sh
+#
+# This script will push the changes to the `documentation` branch of this repository.
+
 set -Eeuo pipefail
 
 TODAY=`date "+%Y%m%d"`
 # we build new versions only for minors and majors
 PATTERN_FOR_NEW_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.0$"
-PATTERN_FOR_PATCH_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.[1-9]+[0-9]*$"
+PATTERN_FOR_MICRO_VERSION="^refs/tags/[0-9]+\\.[0-9]+\\.[1-9][0-9]*$"
 MAIN_REF=refs/heads/main
 VARIABLES_JSON=docs/docs/variables.json
 SOURCES_FILES=docs/docs/sources/
 CHANGELOG=docs/docs/changelog.mdx
 
 [[ ! $GITHUB_REF =~ $PATTERN_FOR_NEW_VERSION ]] \
-&& [[ ! $GITHUB_REF =~ $PATTERN_FOR_PATCH_VERSION ]] \
+&& [[ ! $GITHUB_REF =~ $PATTERN_FOR_MICRO_VERSION ]] \
 && [[ $GITHUB_REF != $MAIN_REF ]] \
 && echo "Not on main or tagged version, skipping." \
 && exit 0
@@ -22,7 +32,7 @@ EXISTING_VERSION=
 if [[ "$GITHUB_REF" =~ $PATTERN_FOR_NEW_VERSION ]]
 then
     NEW_VERSION=${GITHUB_REF/refs\/tags\//}
-elif [[ "$GITHUB_REF" =~ $PATTERN_FOR_PATCH_VERSION ]]
+elif [[ "$GITHUB_REF" =~ $PATTERN_FOR_MICRO_VERSION ]]
 then
     EXISTING_VERSION=$(echo $GITHUB_REF | sed -E "s/^refs\/tags\/([0-9]+)\.([0-9]+)\.[0-9]+$/\1.\2.0/")
 fi


### PR DESCRIPTION
**Proposed changes**:
- Fix regex pattern in doc release script to match all micros. Until now it matched all the micros not containing a "0" digit (`2.2.1`, `2.2.7`, `2.2.12`), missing micros like `2.2.10` or `2.2.20`

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
