### PR TITLE
script to update path of sources loaded with remark-source to a versioned path

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -18,7 +18,8 @@
     "copy-md-files": "node scripts/copy_md_files.js",
     "included-sources": "node scripts/compile_included_sources.js",
     "clean": "find docs/sources -type f -not -name '.keep' -print0 | xargs -0  -I {} rm {}",
-    "ci": "yarn install --frozen-lockfile"
+    "ci": "yarn install --frozen-lockfile",
+    "update-versioned-sources": "node scripts/update_versioned_sources.js"
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-alpha.63",

--- a/docs/plugins/included_source.js
+++ b/docs/plugins/included_source.js
@@ -2,16 +2,14 @@
     This plugin gives us the ability to include source files
     in a code-block in the docs, by using the following
     syntax:
-
         ```python (docs/sources/path/to/file.py)
         ```
-
     To make it work, you need to prefix the source file by `docs/sources/`.
-
     It relies on `remark-source` and on a pre-build phase,
     before docusaurus is started (or built). It allows us to support separate
     versions of the docs (and of the program outputs).
 */
+const path = require('path');
 const fs = require('fs-extra');
 const globby = require('globby');
 
@@ -19,28 +17,29 @@ const { readFile, outputFile } = fs;
 
 const defaultOptions = {
     docsDir: './docs',
-    sourceDir: './docs/sources',
+    relativeSourceDir: 'sources',
     include: ['**.mdx', '**.md'],
     pathPrefix: '../',
 };
+
+const _getIncludedSourceRe = (sourceDir) => `\`\`\`([a-z\-]+) \\(${sourceDir}/([^\\]\\s]+)\\)\n\`\`\``;
 
 /**
     This function is used copy the included sources
     requested in the docs. It parses all the docs files,
     finds the included sources and copy them under the `sourceDir`.
-
     Options:
-    - docsDir:        the directory containing the docs files
-    - sourceDir:      the directory that will contain the included sources
-    - include:        list of patterns to look for doc files
-    - pathPrefix:     a path prefix to use for reading the sources
+    - docsDir:             the directory containing the docs files
+    - relativeSourceDir:   the directory that will contain the included sources
+    - include:             list of patterns to look for doc files
+    - pathPrefix:          a path prefix to use for reading the sources
 */
 async function getIncludedSources(options) {
 
     options = { ...defaultOptions, ...options };
-    const { docsDir, include, sourceDir, pathPrefix } = options;
-    const cleanedSourceDir = sourceDir.replace('./', '');
-    const includedSourceRe =`\`\`\`[a-z\-]+ \\(${cleanedSourceDir}/([^\\]\\s]+)\\)\n\`\`\``;
+    const { docsDir, include, relativeSourceDir, pathPrefix } = options;
+    const cleanedSourceDir = path.join(docsDir.replace('./', ''), relativeSourceDir);
+    const includedSourceRe = _getIncludedSourceRe(cleanedSourceDir);
 
     // first, gather all the docs files
     const docsFiles = await globby(include, {
@@ -56,7 +55,7 @@ async function getIncludedSources(options) {
         // there can be multiple sources in the same file
         const re = new RegExp(includedSourceRe, 'gi');
         while ((group = re.exec(data)) !== null) {
-            sourceFile = group[1];
+            sourceFile = group[2];
             if (seen.has(sourceFile)) {
                 continue;
             }
@@ -69,11 +68,60 @@ async function getIncludedSources(options) {
     }));
     sourceFiles = sourceFiles.flat().filter(pair => pair.length > 0);
 
-    // finally, write all the source files in the `sourceDir`
+    // finally, write all the source files in the source directory
     return await Promise.all(sourceFiles.map(async ([sourceFile, content]) => {
-        return await outputFile(`${sourceDir}/${sourceFile}`, content);
+        return await outputFile(`${docsDir}/${relativeSourceDir}/${sourceFile}`, content);
     }));
 };
 
 
+/**
+    This function is used to ensure that all the documentation files
+    which rely on the `remark-source` plugin to load source files into
+    the docs continue to work across documentation versions. There is no way for
+    `remark-source` to know about the file structure that we have, that's
+    why we need this extra function. The workflow is:
+    1. Doc files are put in a version folder upon release of a new version;
+    2. The files, previously on the `main` branch, used to point to source files
+       contained in `docs/source/...`;
+    3. Now that they are in a versioned folder, we need to them to point to source files
+       contained in `versioned_docs/version-xxx/sources/...`. This is what this function
+       does.
+    Options:
+    - docsDir:                the directory containing the versionned docs files
+    - relativeSourceDir:      the directory that will contain the included sources
+    - include:                list of patterns to look for doc files
+*/
+async function updateVersionedSources(options) {
+    options = { ...defaultOptions, ...options };
+    const { docsDir, include, relativeSourceDir } = options;
+    const originalSourceDir = path.join(defaultOptions.docsDir.replace('./', ''), relativeSourceDir);
+    const newSourceDir = path.join(docsDir.replace('./', ''), relativeSourceDir);
+    const includedSourceRe = _getIncludedSourceRe(originalSourceDir);
+
+    // first, gather all the docs files
+    const docsFiles = await globby(include, {
+      cwd: docsDir,
+    });
+    const seen = new Set();
+    // second, read every doc file and compute their updated content
+    let newDocsFiles = await Promise.all(docsFiles.map(async (source) => {
+        const data = await readFile(`${docsDir}/${source}`);
+        // third, find out if there is a source to be included
+        // there can be multiple sources in the same file
+        const re = new RegExp(includedSourceRe, 'gi');
+        const updatedData = data.toString().replace(re, `\`\`\`$1 (${newSourceDir}/$2)\n\`\`\``);
+        return (updatedData != data) ? [`${docsDir}/${source}`, updatedData] : [];
+    }));
+
+    newDocsFiles = newDocsFiles.filter(pair => pair.length > 0);
+
+    // finally, update all the docs files with the path to the versioned source
+    return await Promise.all(newDocsFiles.map(async ([docsFile, updatedContent]) => {
+        return await outputFile(docsFile, updatedContent);
+    }));
+}
+
+
 module.exports = getIncludedSources;
+module.exports.updateVersionedSources = updateVersionedSources;

--- a/docs/scripts/update_versioned_sources.js
+++ b/docs/scripts/update_versioned_sources.js
@@ -1,0 +1,16 @@
+const fs = require("fs");
+const includedSources = require('../plugins/included_source.js');
+
+
+const version = process.argv[2];
+if (!version) {;
+    throw new Error("Missing version argument.");
+}
+
+const docsDir = `./versioned_docs/version-${version}`;
+if (!fs.existsSync(docsDir)) {
+    throw new Error(`Documentation for version ${version} doesn't exist.`);
+}
+
+console.info(`Updating sources in ${version} documentation`);
+includedSources.updateVersionedSources({ docsDir });

--- a/scripts/push_docs_to_branch.sh
+++ b/scripts/push_docs_to_branch.sh
@@ -68,6 +68,12 @@ else
     fi
 fi
 
+CURRENTLY_EDITING_VERSION=${EXISTING_VERSION:-$NEW_VERSION}
+if [ -n "$CURRENTLY_EDITING_VERSION" ]
+then
+    cd $TMP_DOCS_FOLDER/docs && yarn run update-versioned-sources -- $CURRENTLY_EDITING_VERSION && cd -
+fi
+
 cd $TMP_DOCS_FOLDER
 
 if [ -z "$(git status --porcelain)" ]


### PR DESCRIPTION
**Proposed changes**:
- Same changes as in this PR: https://github.com/RasaHQ/rasa/pull/7961
- After merging this, we'll need to execute the script on the `documentation` branch for all previous 2.x versions

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
