### PR TITLE
Tiny Changelog error - pointing at wrong project

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -265,7 +265,7 @@ https://github.com/RasaHQ/rasa/tree/main/changelog/ . -->
 ### Features
 
 
-* [#164](https://github.com/rasahq/rasa/issues/164): Added new `--auto-reload` CLI argument. When specified, modules containing `Action`
+* [#164](https://github.com/RasaHQ/rasa-sdk/pull/164): Added new `--auto-reload` CLI argument. When specified, modules containing `Action`
 subclasses will be automatically reloaded if they have been modified since the last HTTP
 request. By using this, one can avoid having to re-start the actions server when
 developing new actions.


### PR DESCRIPTION
Hope it's obvious from the change but the --auto-reload bullet point was incorrectly pointing at an issue within the rasa project when it was meant to be the PR with a matching number in the rasa-sdk project.
This just fixes that tiny (but confusing) little mistake 🙂

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
