### PR TITLE
PR for issue 434, making rasa action server listen on a specific inte…

### DIFF
--- a/changelog/434.improvement.md
+++ b/changelog/434.improvement.md
@@ -1,0 +1,2 @@
+- The action server can now listen on a specific network address using the environment variable `SANIC_HOST` instead
+- Corrected url which is logged at action server startup

--- a/changelog/434.improvement.md
+++ b/changelog/434.improvement.md
@@ -1,2 +1,2 @@
-- The action server can now listen on a specific network address using the environment variable `SANIC_HOST` instead
+- The action server can now listen on a specific network address using the environment variable `SANIC_HOST` instead of listening on all host interfaces by default
 - Corrected url which is logged at action server startup

--- a/docs/docs/running-action-server.mdx
+++ b/docs/docs/running-action-server.mdx
@@ -14,10 +14,23 @@ If `rasa` is installed, you can run the action server using a `rasa` command:
 rasa run actions
 ```
 
+Alternatively you can make your assistent listen on a specific address using the `SANIC_HOST` environment
+variable:
+
+```bash
+SANIC_HOST=192.168.69.150 rasa run actions
+```
+
 If `rasa` is not installed, you can run the action server directly as a python module:
 
 ```bash
 python -m rasa_sdk --actions actions
+```
+
+Running the action server directly as a python module allows for `SANIC_HOST` too:
+
+```bash
+SANIC_HOST=192.168.69.150 python -m rasa_sdk --actions actions
 ```
 
 Using the command above, `rasa_sdk` will expect to find your actions 

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 import types
 from typing import List, Text, Union, Optional, Any
 from ssl import SSLContext
@@ -139,9 +140,10 @@ def run(
     )
     ssl_context = create_ssl_context(ssl_certificate, ssl_keyfile, ssl_password)
     protocol = "https" if ssl_context else "http"
+    host = os.environ.get("SANIC_HOST", "0.0.0.0")
 
-    logger.info(f"Action endpoint is up and running on {protocol}://localhost:{port}")
-    app.run("0.0.0.0", port, ssl=ssl_context, workers=utils.number_of_sanic_workers())
+    logger.info(f"Action endpoint is up and running on {protocol}://{host}:{port}")
+    app.run(host, port, ssl=ssl_context, workers=utils.number_of_sanic_workers())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…rface

**Proposed changes**:
- Restrict the network interfaces used by rasa to one specific address instead of 0.0.0.0
- Fixes the network address logged at server startup

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
