### PR TITLE
preserving the order of slots to be validated (rather than reversed) + making updated slot value immediately visible to extract/validate of subsequent slots.

### DIFF
--- a/changelog/441.improvement.md
+++ b/changelog/441.improvement.md
@@ -1,0 +1,3 @@
+Slots will be validated in order they are requested. Previously, they were validated in reverse order.
+
+Already extracted slots are now immediately visible during extraction of subsequent slots. Same goes for validation.

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -864,6 +864,9 @@ class FormValidationAction(Action, ABC):
 
             if isinstance(validation_output, dict):
                 slots.update(validation_output)
+                # for sequential consistency, also update tracker
+                # to make changes visible to subsequent validate_{slot_name}
+                tracker.slots.update(validation_output)
             else:
                 warnings.warn(
                     f"Cannot validate `{slot_name}`: make sure the validation method "

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -730,16 +730,21 @@ class FormValidationAction(Action, ABC):
         Returns:
             `SlotSet` for any extracted slots.
         """
-        custom_slots = []
+        custom_slots = {}
         slots_to_extract = await self.required_slots(
             self.slots_mapped_in_domain(domain), dispatcher, tracker, domain
         )
 
         for slot_name in slots_to_extract:
-            custom_slots += await self._extract_slot(
+            extraction_output = await self._extract_slot(
                 slot_name, dispatcher, tracker, domain
             )
-        return custom_slots
+            custom_slots.update(extraction_output)
+            # for sequential consistency, also update tracker
+            # to make changes visible to subsequent extract_{slot_name}
+            tracker.slots.update(extraction_output)
+
+        return [SlotSet(slot, value) for slot, value in custom_slots.items()]
 
     async def _extract_slot(
         self,
@@ -747,7 +752,7 @@ class FormValidationAction(Action, ABC):
         dispatcher: "CollectingDispatcher",
         tracker: "Tracker",
         domain: "DomainDict",
-    ) -> List[EventType]:
+    ) -> Dict[Text, Any]:
         method_name = f"extract_{slot_name.replace('-', '_')}"
         slot_mapped_in_domain = slot_name in self.slots_mapped_in_domain(domain)
         extract_method = getattr(self, method_name, None)
@@ -758,9 +763,7 @@ class FormValidationAction(Action, ABC):
                     f"No method '{method_name}' found for slot "
                     f"'{slot_name}'. Skipping extraction for this slot."
                 )
-                return []
-            else:
-                return []
+            return {}
 
         if extract_method and slot_mapped_in_domain:
             warnings.warn(
@@ -776,13 +779,13 @@ class FormValidationAction(Action, ABC):
         )
 
         if isinstance(extracted, dict):
-            return [SlotSet(slot, value) for slot, value in extracted.items()]
+            return extracted
 
         warnings.warn(
             f"Cannot extract `{slot_name}`: make sure the extract method "
             f"returns the correct output."
         )
-        return []
+        return {}
 
     async def required_slots(
         self,

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -259,7 +259,7 @@ class Tracker:
                 # checked all potential slot candidates.
                 break
 
-        for event in self.events[len(self.events)-count:]:
+        for event in self.events[len(self.events) - count :]:
             slots[event["name"]] = event["value"]
 
         return slots

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -247,16 +247,20 @@ class Tracker:
         """
 
         slots: Dict[Text, Any] = {}
+        count: int = 0
 
         for event in reversed(self.events):
             # The `FormAction` in Rasa Open Source will append all slot candidates
             # at the end of the tracker events.
             if event["event"] == "slot":
-                slots[event["name"]] = event["value"]
+                count += 1
             else:
                 # Stop as soon as there is another event type as this means that we
                 # checked all potential slot candidates.
                 break
+
+        for event in self.events[len(self.events)-count:]:
+            slots[event["name"]] = event["value"]
 
         return slots
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1534,10 +1534,6 @@ class TestFormValidationAction(FormValidationAction):
             return {
                 "slot2": "validated_value",
             }
-        if tracker.get_slot("slot1") == "validated_value":
-            return {
-                "slot2": "slot1 == validated_value",
-            }
         return {
             "slot2": None,
         }
@@ -1585,7 +1581,7 @@ async def test_form_validation_action():
     assert not warnings
     assert events == [
         SlotSet("slot1", "validated_value"),
-        SlotSet("slot2", "slot1 == validated_value"),
+        SlotSet("slot2", None),
     ]
 
 
@@ -1650,7 +1646,7 @@ async def test_form_validation_without_validate_function():
 
     assert events == [
         SlotSet("slot1", "validated_value"),
-        SlotSet("slot2", "slot1 == validated_value"),
+        SlotSet("slot2", None),
         SlotSet("slot3", "some_value"),
     ]
 
@@ -1813,13 +1809,22 @@ async def test_extract_and_validate_slot(
     "my_required_slots, extracted_values, asserted_events",
     [
         (
+            # request slot "state" before "city"
             ["state", "city"],
+            # both are extracted as follow
             {"state": "california", "city": "san francisco"},
+            # validate_state turns "california" to "CA"
+            # validate_city sees "state" == "CA" and turns "san francisco" to "San Francisco"
             [["state", "CA"], ["city", "San Francisco"], [REQUESTED_SLOT, None]],
         ),
         (
+            # request slot "city" before "state"
             ["city", "state"],
+            # only "city" can be extracted from user message
+            # seeing "city" == "san francisco", "state" is extracted as "california"
             {"state": None, "city": "san francisco"},
+            # validate_city keeps "city" as is
+            # validate_state turns "california" to "CA"
             [["city", "san francisco"], ["state", "CA"], [REQUESTED_SLOT, None]],
         ),
     ],

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1534,6 +1534,10 @@ class TestFormValidationAction(FormValidationAction):
             return {
                 "slot2": "validated_value",
             }
+        if tracker.get_slot("slot1") == "validated_value":
+            return {
+                "slot2": "slot1 == validated_value",
+            }
         return {
             "slot2": None,
         }
@@ -1580,8 +1584,8 @@ async def test_form_validation_action():
 
     assert not warnings
     assert events == [
-        SlotSet("slot2", None),
         SlotSet("slot1", "validated_value"),
+        SlotSet("slot2", "slot1 == validated_value"),
     ]
 
 
@@ -1645,9 +1649,9 @@ async def test_form_validation_without_validate_function():
         )
 
     assert events == [
-        SlotSet("slot3", "some_value"),
-        SlotSet("slot2", None),
         SlotSet("slot1", "validated_value"),
+        SlotSet("slot2", "slot1 == validated_value"),
+        SlotSet("slot3", "some_value"),
     ]
 
 


### PR DESCRIPTION
According to the following question in the forum, slots should be validated in the order they are defined in required_slots method.

https://forum.rasa.com/t/what-is-the-order-of-execution-of-validate-slot-name-functions-in-formaction-feature/14562

But what I observed is that the order is actually reversed from that specified in my required_slots in FormValidationAction. I traced it to this code and found that the order gets reversed here. 

[For the second commit] Also, when there are multiple slots to be validated in a single message, it is easier to understand and code if during validation of the second slot we see the updated value of the first slot.

Example: How is the weather in \[San Francisco\](city), \[California\](state)?

In this case, we may want to validate "state" before "city". Our database may use abbreviation for state name, so after validating the "state", we may want to convert it to "CA". And when we validate the "city", we may have to use it in conjunction with "CA" to look up from our database. Without the proposed change, the slot "state" would still have its original value "California" during validation of the slot "city".

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
