### PR TITLE
Fix mistake in knowledge base action story example

### DIFF
--- a/docs/docs/knowledge-base-actions.mdx
+++ b/docs/docs/knowledge-base-actions.mdx
@@ -242,7 +242,7 @@ stories:
   steps:
   - intent: greet
   - action: utter_greet
-  - intent: utter_greet
+  - intent: query_knowledge_base
   - action: action_query_knowledge_base
   - intent: goodbye
   - action: utter_goodbye


### PR DESCRIPTION
"utter_greet" is incorrectly listed as an intent in the knowledge base action story.  Replacing with correct intent "query_knowledge_base"

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [n/a?] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [n/a] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
