### PR TITLE
Add docs to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,15 @@ updates:
       - RasaHQ/enable-squad
     labels:
       - type:dependencies
+  - package-ecosystem: npm
+    directory: "/docs"
+    schedule:
+      interval: monthly
+      time: '13:00'
+    pull-request-branch-name:
+      separator: "-"
+    open-pull-requests-limit: 10
+    reviewers:
+      - RasaHQ/enable-squad
+    labels:
+      - type:dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: '13:00'
-  pull-request-branch-name:
-    separator: "-"
-  open-pull-requests-limit: 10
-  reviewers:
-  - RasaHQ/enable-squad
-  labels:
-  - type:dependencies
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: '13:00'
+    pull-request-branch-name:
+      separator: "-"
+    open-pull-requests-limit: 10
+    reviewers:
+      - RasaHQ/enable-squad
+    labels:
+      - type:dependencies


### PR DESCRIPTION
**Proposed changes**:
- Add `/docs` to dependabot, auto-assign to `@RasaHQ/scale-squad`