### PR TITLE
Remove warning for custom slot mappings

### DIFF
--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -231,15 +231,6 @@ class ValidationAction(Action, ABC):
                 )
             return {}
 
-        if extract_method and slot_in_domain:
-            warnings.warn(
-                f"Slot '{slot_name}' is mapped in the domain and your custom "
-                f"action defines '{method_name}'. '{method_name}' will override any "
-                f"extractions of the predefined slot mapping from the domain. It is "
-                f"suggested to define a slot mapping in only one of the two ways for "
-                f"clarity."
-            )
-
         extracted = await utils.call_potential_coroutine(
             extract_method(dispatcher, tracker, domain)
         )


### PR DESCRIPTION
**Proposed changes**:
-  Removes outdated warning for the extraction of custom slot mappings that should be defined in 3.0 domain format.
(closes issue in rasa repo: https://github.com/RasaHQ/rasa/issues/10116)

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
