### PR TITLE
fix missing env vars in workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,6 +20,9 @@ on:
 env:
   DOCS_FOLDER: docs
   DOCS_BRANCH: documentation
+  TAG_NAME: ${GITHUB_REF#refs/tags/}
+  IS_TAG_BUILD: ${{ startsWith(github.event.ref, 'refs/tags') }}
+  IS_MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:
   changes:


### PR DESCRIPTION
Relates to https://github.com/RasaHQ/rasa-sdk/pull/628

Adds missing env vars at the top of the documentation workflow