### PR TITLE
rename enable-squad -> atom-squad

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       separator: "-"
     open-pull-requests-limit: 10
     reviewers:
-      - RasaHQ/enable-squad
+      - RasaHQ/atom-squad
     labels:
       - type:dependencies
   - package-ecosystem: npm
@@ -21,6 +21,6 @@ updates:
       separator: "-"
     open-pull-requests-limit: 10
     reviewers:
-      - RasaHQ/enable-squad
+      - RasaHQ/atom-squad
     labels:
       - type:dependencies


### PR DESCRIPTION
**Proposed changes**:
- Rename in dependabot config
- @joejuzl can you rename the RasaHQ/enable-squad GitHub handle to RasaHQ/atom-squad upon merge of this PR?

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
