### PR TITLE
Update /docs/rasa-x links

### DIFF
--- a/docs/docs/deploy-action-server.mdx
+++ b/docs/docs/deploy-action-server.mdx
@@ -211,7 +211,7 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
-    name: Build Action Server image and upgrade Rasa X deployment
+    name: Build Action Server image and upgrade Rasa Enterprise deployment
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -235,7 +235,7 @@ jobs:
 
 4. Now, you can use your new brand docker image.
 
-5. You can also extend your workflow, so that you do not have to manually update your Rasa X deployment. The example below shows how to extend your workflow with an additional step that updates a Rasa X [Helm Chart](https://rasa.com/docs/rasa-x/installation-and-setup/customize/#adding-a-custom-action-server) deployment.
+5. You can also extend your workflow, so that you do not have to manually update your Rasa Enterprise deployment. The example below shows how to extend your workflow with an additional step that updates a Rasa Enterprise [Helm Chart](https://rasa.com/docs/rasa-enterprise/installation-and-setup/customize/#adding-a-custom-action-server) deployment.
 
 ```yaml
 on:
@@ -246,7 +246,7 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
-    name: Build Action Server image and upgrade Rasa X deployment
+    name: Build Action Server image and upgrade Rasa Enterprise deployment
     steps:
     [..]
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -12,9 +12,9 @@ try { existingVersions = require('./versions.json'); } catch (e) { console.info(
 
 const BASE_URL = '/docs/action-server/';
 const SITE_URL = 'https://rasa.com';
-// NOTE: this allows switching between local dev instances of rasa/rasa and rasa/rasa-x
+// NOTE: this allows switching between local dev instances of rasa/rasa and rasa/rasa-enterprise
 const RASA_OPEN_SOURCE_SWAP_URL = isDev ? 'http://localhost:3000' : SITE_URL;
-const RASA_X_SWAP_URL = isDev ? 'http://localhost:3001' : SITE_URL;
+const RASA_ENTERPRISE_SWAP_URL = isDev ? 'http://localhost:3001' : SITE_URL;
 
 const versionLabels = {
   current: 'Main/Unreleased'
@@ -60,9 +60,9 @@ module.exports = {
           position: 'left',
         },
         {
-          label: 'Rasa X',
+          label: 'Rasa Enterprise',
           position: 'left',
-          href: `${RASA_X_SWAP_URL}/docs/rasa-x/`,
+          href: `${RASA_ENTERPRISE_SWAP_URL}/docs/rasa-enterprise/`,
           target: '_self',
         },
         {


### PR DESCRIPTION
**Proposed changes**:
- Addresses https://rasahq.atlassian.net/browse/RS-8
- Update the links pointing at `/docs/rasa-x` to `/docs/rasa-enterprise` in the docs
- Update wording from `Rasa X` to `Rasa Enterprise` (it was so small that I couldn't resist)

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
