### PR TITLE
Fix spelling error in knowledge-base-actions docs

### DIFF
--- a/docs/docs/knowledge-base-actions.mdx
+++ b/docs/docs/knowledge-base-actions.mdx
@@ -147,7 +147,7 @@ nlu:
     - list some [restaurants]{"entity": "object_type", "value": "restaurant"}
     - can you name some [restaurants]{"entity": "object_type", "value": "restaurant"} please?
     - can you show me some [restaurants]{"entity": "object_type", "value": "restaurant"} options
-    - list [German](cuisine) [restaurants]{"entity": "sobject_type", "value": "restaurant"}
+    - list [German](cuisine) [restaurants]{"entity": "object_type", "value": "restaurant"}
     - do you have any [mexican](cuisine) [restaurants]{"entity": "object_type", "value": "restaurant"}?
     - do you know the [price range]{"entity": "attribute", "value": "price-range"} of [that one](mention)?
     - what [cuisine](attribute) is [it](mention)?


### PR DESCRIPTION
**Proposed changes**:
- Fix "sobject_type" spelling error in knowledge-base-actions docs
- #789

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
