### PR TITLE
2.8.x allow external logging formatters

### DIFF
--- a/rasa_sdk/__main__.py
+++ b/rasa_sdk/__main__.py
@@ -26,14 +26,11 @@ def main_from_args(args):
             invalidate_caches()
             import_module(name=logger_path)
             # update root level
-            logging.getLogger(__name__).warning(f"set root level to {args.loglevel}")
+            logging.getLogger(__name__).debug(f"set root level to {args.loglevel}")
             logging.basicConfig(level=args.loglevel, force=True)
-
-            print("===CATCHME======")
         except Exception as e:
             default_logging(args)
             logging.getLogger(__name__).exception("custom logger import failed", exc_info=e)
-            print("===CAUGHT++++++++")
     else:
         default_logging(args)
 

--- a/rasa_sdk/__main__.py
+++ b/rasa_sdk/__main__.py
@@ -26,9 +26,14 @@ def main_from_args(args):
             invalidate_caches()
             import_module(name=logger_path)
             # update root level
-            logging.root.level = args.loglevel
-        except Exception:
+            logging.getLogger(__name__).warning(f"set root level to {args.loglevel}")
+            logging.basicConfig(level=args.loglevel, force=True)
+
+            print("===CATCHME======")
+        except Exception as e:
             default_logging(args)
+            logging.getLogger(__name__).exception("custom logger import failed", exc_info=e)
+            print("===CAUGHT++++++++")
     else:
         default_logging(args)
 

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -117,8 +117,10 @@ def create_app(
         return response.json(body, status=200)
 
     @app.exception(Exception)
-    async def something_bad_happened(request, exception: Exception):
-        logger.error(msg=f"{exception=}", exc_info=exception)
+    async def exception_handler(request, exception: Exception):
+        logger.error(
+            msg=f"Exception occurred during execution of request {request}", exc_info=exception
+        )
         body = {"error": exception, "request": request}
         return response.json(body, status=500)
 


### PR DESCRIPTION
**Proposed changes**:
To be able to use structured logging, there has to be a dedicated method to define the logger for the Rasa SDK server:
- introduce an environment variable `RASA_LOGGER_PYMODULE` to store the python package name of the custom logger
- catch the previously uncaught exceptions from route handlers, so the exception output is also logged and not written to stderr in plain text.

Background: we use GrayLog with JSON extractor for all our servers, and 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
