### PR TITLE
created catch all for exceptions to handle them properly

### DIFF
--- a/changelog/836.improvement.md
+++ b/changelog/836.improvement.md
@@ -1,0 +1,1 @@
+Return a json response when encountering action execution exceptions. Log exceptions using logger rather than sanic default print.

--- a/docs/static/spec/action-server.yml
+++ b/docs/static/spec/action-server.yml
@@ -77,18 +77,30 @@ paths:
         500:
           description: >-
             The action server encountered an exception while running the action.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  request_body:
+                    type: object
+                    description: >-
+                      Json body of the incoming request that resulted in the error.
+                  error:
+                    type: string
+                    description: The error message.
 components:
   schemas:
     Response:
       allOf:
-        - $ref: '#/components/schemas/TextResponse'
-        - $ref: '#/components/schemas/ButtonResponse'
-        - $ref: '#/components/schemas/ElementResponse'
-        - $ref: '#/components/schemas/CustomResponse'
-        - $ref: '#/components/schemas/ImageResponse'
-        - $ref: '#/components/schemas/AttachmentResponse'
-        - $ref: '#/components/schemas/TemplateResponse'
-        - $ref: '#/components/schemas/ResponseResponse'
+        - $ref: "#/components/schemas/TextResponse"
+        - $ref: "#/components/schemas/ButtonResponse"
+        - $ref: "#/components/schemas/ElementResponse"
+        - $ref: "#/components/schemas/CustomResponse"
+        - $ref: "#/components/schemas/ImageResponse"
+        - $ref: "#/components/schemas/AttachmentResponse"
+        - $ref: "#/components/schemas/TemplateResponse"
+        - $ref: "#/components/schemas/ResponseResponse"
 
     TextResponse:
       description: Text which the bot should utter.
@@ -126,7 +138,7 @@ components:
         buttons:
           type: array
           items:
-            $ref: '#/components/schemas/Button'
+            $ref: "#/components/schemas/Button"
     ElementResponse:
       description: Custom elements which should be sent to the user.
       type: object

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -122,6 +122,14 @@ def create_app(
         body = [{"name": k} for k in executor.actions.keys()]
         return response.json(body, status=200)
 
+    @app.exception(Exception)
+    async def exception_handler(request, exception: Exception):
+        logger.error(
+            msg=f"Exception occurred during execution of request {request}", exc_info=exception
+        )
+        body = {"error": str(exception), "request_body": request.json}
+        return response.json(body, status=500)
+    
     return app
 
 

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -125,7 +125,8 @@ def create_app(
     @app.exception(Exception)
     async def exception_handler(request, exception: Exception):
         logger.error(
-            msg=f"Exception occurred during execution of request {request}", exc_info=exception
+            msg=f"Exception occurred during execution of request {request}",
+            exc_info=exception,
         )
         body = {"error": str(exception), "request_body": request.json}
         return response.json(body, status=500)

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -129,7 +129,7 @@ def create_app(
         )
         body = {"error": str(exception), "request_body": request.json}
         return response.json(body, status=500)
-    
+
     return app
 
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -30,3 +30,16 @@ class CustomAction(Action):
         domain: DomainDict,
     ) -> List[Dict[Text, Any]]:
         return [SlotSet("test", "bar")]
+
+
+class CustomActionRaisingException(Action):
+    def name(cls) -> Text:
+        return "custom_action_exception"
+
+    def run(
+        self,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: DomainDict,
+    ) -> List[Dict[Text, Any]]:
+        raise Exception("test exception")

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -48,6 +48,7 @@ def test_server_webhook_handles_action_exception():
     assert response.json.get("error") == "test exception"
     assert response.json.get("request_body") == data
 
+
 def test_server_webhook_custom_action_returns_200():
     data = {
         "next_action": "custom_action",


### PR DESCRIPTION
**Proposed changes**:
- handle exceptions thrown in custom actions
- return a 500 response code as well as information about the error 
- compatible change since we already by default returned a 500 (sanic default). but exception was not properly logged to logger
