### PR TITLE
fixed release note generation

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -17,15 +17,25 @@ https://github.com/RasaHQ/rasa/tree/main/changelog/ . -->
 
 <!-- TOWNCRIER -->
 
-## [3.2.1] - 2022-08-30 No significant changes.
+## [3.2.1] - 2022-08-30
 
-## [3.2.0] - 2022-06-14 No significant changes.
+No significant changes.
 
-## [3.1.2] - 2022-06-08 No significant changes.
+## [3.2.0] - 2022-06-14
 
-## [3.1.1] - 2022-03-24 No significant changes.
+No significant changes.
 
-## [3.1.0] - 2022-03-23 No significant changes.
+## [3.1.2] - 2022-06-08
+
+No significant changes.
+
+## [3.1.1] - 2022-03-24
+
+No significant changes.
+
+## [3.1.0] - 2022-03-23
+
+No significant changes.
 
 ## [3.0.6] - 2022-03-07
 

--- a/changelog/_template.md.jinja2
+++ b/changelog/_template.md.jinja2
@@ -5,6 +5,8 @@
 {% if definitions[category]['showcontent'] %}{% for text, values in sections[section][category]|dictsort(by='value') %}{% set issue_joiner = joiner(', ') %}- {% for value in values|sort %}{{ issue_joiner() }}{{ value }}{% endfor %}: {{ text }}
 {% endfor %}{% else %}- {{ sections[section][category]['']|sort|join(', ') }}{% endif %}{% if sections[section][category]|length == 0 %} No significant changes.
 
-{% else %}{% endif %}{% endfor %}{% else %} No significant changes.
+{% else %}{% endif %}{% endfor %}{% else %} 
+
+No significant changes.
 
 {% endif %}{% endfor %}

--- a/scripts/publish_gh_release_notes.py
+++ b/scripts/publish_gh_release_notes.py
@@ -57,8 +57,11 @@ def parse_changelog(tag_name: Text) -> Text:
         if consuming_version:
             version_lines.append(line)
 
-    # drop the first lines (version headline, not needed for GH)
-    return "\n".join(version_lines[2:]).strip()
+    if consuming_version:
+        # drop the first lines (version headline, not needed for GH)
+        return "\n".join(version_lines[2:]).strip()
+    else:
+        return None
 
 
 def main():
@@ -83,7 +86,7 @@ def main():
     else:
         md_body = parse_changelog(tag_name)
 
-    if not md_body:
+    if md_body is None:
         print("Failed to extract changelog entries for version from changelog.")
         return 2
 


### PR DESCRIPTION
**Proposed changes**:
- fixed release note generation
- adds some whitespace to the changelog
- fixed the github release notes script to work even if no content is added for release (but still fail if the content can not be found at all)