### PR TITLE
Restore deps install in ci

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,6 +56,9 @@ jobs:
           # can calculate the proper diff between the branches
           git fetch --unshallow origin "${{ github.ref }}"
 
+      - name: Install Dependencies 📦
+        run: make install
+
       - name: Lint Code 🎎
         run: |
           # If it's not a pull request, $DOCSTRING_DIFF_BRANCH is unset.


### PR DESCRIPTION
**Proposed changes**:
- `make install` was accidentally removed from the workflow. This PR restores it.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
