### PR TITLE
Fix GitHub runners to use ubuntu-20.04

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   quality:
     name: Code Quality
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout git repository 🕝
@@ -85,7 +85,7 @@ jobs:
 
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
@@ -131,7 +131,7 @@ jobs:
 
   docker_linter:
     name: Lint Dockerfile
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Lint Dockerfile
@@ -141,7 +141,7 @@ jobs:
 
   build_docker_image_set_env:
     name: Prepare environment for Docker build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       # Tag name used for intermediate images created during Docker image builds, e.g. 3886 - a PR number
       image_tag: ${{ steps.set_output.outputs.image_tag }}
@@ -224,7 +224,7 @@ jobs:
 
   build_docker_image:
     name: Build Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [quality, test, docker_linter, build_docker_image_set_env]
 
     steps:
@@ -275,7 +275,7 @@ jobs:
 
   deploy:
     name: Deploy to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # deploy will only be run when there is a tag available
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   changes:
     name: Check for file changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # don't run this for pull requests of forks
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'RasaHQ/rasa-sdk'
     outputs:
@@ -52,7 +52,7 @@ jobs:
 
   evaluate_release_tag:
     name: Evaluate release tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # don't run this for main branches of forks, would fail anyways
     if: github.repository == 'RasaHQ/rasa-sdk' && github.ref != 'refs/heads/documentation' && github.event_name != 'pull_request'
     outputs:
@@ -122,7 +122,7 @@ jobs:
 
   prebuild_docs:
     name: Prebuild Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [ evaluate_release_tag ]
     # don't run this for main branches of forks, would fail anyways
     if: github.repository == 'RasaHQ/rasa-sdk' && needs.evaluate_release_tag.outputs.build_docs == 'true' && github.ref != 'refs/heads/documentation' && github.event_name != 'pull_request'
@@ -200,7 +200,7 @@ jobs:
 
   preview_docs:
     name: Preview Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [ changes ]
     # don't run this for pull requests of forks
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'RasaHQ/rasa-sdk'
@@ -283,7 +283,7 @@ jobs:
 
   publish_docs:
     name: Publish Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # don't run this for main branches of forks; only run on documentation branch
     if: github.repository == 'RasaHQ/rasa-sdk' && github.ref == 'refs/heads/documentation'
 

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   cleanup_runs:
     name: Cancel old branch builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
 
     steps:
@@ -18,7 +18,7 @@ jobs:
 
   gitleaks:
     name: Detecting hardcoded secrets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   spellcheck:
     name: Typo CI (GitHub Action)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 4
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:


### PR DESCRIPTION
Proposed changes:

- Pin CI runners to use Ubuntu 20.04 instead of an arbitrary "latest" build to avoid workflows breaking.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
