### PR TITLE
Fix GitHub runners to use ubuntu-20.04

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   quality:
     name: Code Quality
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout git repository 🕝
@@ -71,7 +71,7 @@ jobs:
 
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10']
@@ -117,7 +117,7 @@ jobs:
 
   docker_linter:
     name: Lint Dockerfile
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Lint Dockerfile
@@ -127,7 +127,7 @@ jobs:
 
   build_docker_image_set_env:
     name: Prepare environment for Docker build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       # Tag name used for intermediate images created during Docker image builds, e.g. 3886 - a PR number
       image_tag: ${{ steps.set_output.outputs.image_tag }}
@@ -210,7 +210,7 @@ jobs:
 
   build_docker_image:
     name: Build Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [quality, test, docker_linter, build_docker_image_set_env]
 
     steps:
@@ -261,7 +261,7 @@ jobs:
 
   deploy:
     name: Deploy to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # deploy will only be run when there is a tag available
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   cleanup_runs:
     name: Cancel old branch builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
 
     steps:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   spellcheck:
     name: Typo CI (GitHub Action)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 4
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:


### PR DESCRIPTION
Proposed changes:

- Pin CI runners to use Ubuntu 20.04 instead of an arbitrary "latest" build to avoid workflows breaking.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
