### PR TITLE
handling deflate encoded data in web hook

### DIFF
--- a/changelog/912.improvement.md
+++ b/changelog/912.improvement.md
@@ -1,0 +1,3 @@
+Added the ability to decompress deflate encoded
+json payloads for the webhook endpoint of the 
+action server.


### PR DESCRIPTION
**Proposed changes**:
- Addresses https://rasahq.atlassian.net/browse/ENG-123
- gives action server the ability to decompress deflate encoded data

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
