### PR TITLE
Add support of validation of slots with . in name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,5 @@ semantic_version = "^2.8.5"
 mypy = "^0.991"
 sanic-testing = "^22.3.0, <22.9.0"
 
-
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,3 @@ pep440-version-utils = "^0.3.0"
 semantic_version = "^2.8.5"
 mypy = "^0.991"
 sanic-testing = "^22.3.0, <22.9.0"
-
-[tool.pytest.ini_options]
-asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,3 +85,7 @@ pep440-version-utils = "^0.3.0"
 semantic_version = "^2.8.5"
 mypy = "^0.991"
 sanic-testing = "^22.3.0, <22.9.0"
+
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/rasa_sdk/forms.py
+++ b/rasa_sdk/forms.py
@@ -153,7 +153,7 @@ class ValidationAction(Action, ABC):
                 slots.pop(slot_name)
                 continue
 
-            method_name = f"validate_{slot_name.replace('-','_')}"
+            method_name = f"validate_{slot_name.replace('-','_').replace('.', '_')}"
             validate_method = getattr(self, method_name, None)
 
             if not validate_method:

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -758,9 +758,9 @@ async def test_extract_slot_only():
         (["my_slot", "other_slot"], {}, [SlotSet(REQUESTED_SLOT, "other_slot")]),
         # Extract method for slot which is also mapped in domain
         (
-            ["my_slot", "other_slot"],
+            ["my_slot"],
             {"forms": {"some_form": {"required_slots": ["my_slot"]}}},
-            [SlotSet(REQUESTED_SLOT, "other_slot")],
+            [],
         ),
     ],
 )
@@ -875,6 +875,7 @@ async def test_ask_for_next_slot(
     assert events == expected_return_events
 
 
+@pytest.mark.asyncio
 async def test_form_validation_space_slot():
     form_name = "some_form"
 


### PR DESCRIPTION
**Proposed changes**:
Support validation actions for slots with `.` in name

To support spaces slots.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
