### PR TITLE
fix: logger message to debug when plugins not found

### DIFF
--- a/changelog/1219.bugfix.md
+++ b/changelog/1219.bugfix.md
@@ -1,0 +1,1 @@
+The logger for rasa_sdk plugin will not throw traceback when no plugins are found since plugins are optional. It will be only available in debug mode, however the action server will continue to run.

--- a/rasa_sdk/plugin.py
+++ b/rasa_sdk/plugin.py
@@ -27,7 +27,7 @@ def _discover_plugins(manager: pluggy.PluginManager) -> None:
 
         rasa_sdk_plugins.init_hooks(manager)
     except ModuleNotFoundError as e:
-        logger.info("No plugins found", exc_info=e)
+        logger.debug("No plugins found", exc_info=e)
         pass
 
 

--- a/rasa_sdk/plugin.py
+++ b/rasa_sdk/plugin.py
@@ -27,7 +27,7 @@ def _discover_plugins(manager: pluggy.PluginManager) -> None:
 
         rasa_sdk_plugins.init_hooks(manager)
     except ModuleNotFoundError as e:
-        logger.debug("No plugins found", exc_info=e)
+        logger.debug("No plugins found: %s", e)
         pass
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,13 +1,12 @@
 import warnings
-import logging
-import pytest 
+
 from pytest import MonkeyPatch
 from pluggy import PluginManager
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from rasa_sdk import endpoint
-from rasa_sdk.plugin import plugin_manager, _discover_plugins
-logger = logging.getLogger(__name__)
+from rasa_sdk.plugin import plugin_manager
+
 
 def test_plugin_manager() -> None:
     manager = plugin_manager()
@@ -42,7 +41,8 @@ def test_plugin_attach_sanic_app_extension(
 
 def test_plugins_not_found(monkeypatch):
     # Mock the import statement to raise ModuleNotFoundError
-    monkeypatch.setitem(__builtins__, 'import', MagicMock(side_effect=ModuleNotFoundError))
+    monkeypatch.setitem(__builtins__, 'import',
+                        MagicMock(side_effect=ModuleNotFoundError))
 
     # Call the method under test
     try:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -39,10 +39,12 @@ def test_plugin_attach_sanic_app_extension(
         endpoint.run("actions")
     manager.hook.attach_sanic_app_extensions.assert_called_once_with(app=app_mock)
 
+
 def test_plugins_not_found(monkeypatch):
     # Mock the import statement to raise ModuleNotFoundError
-    monkeypatch.setitem(__builtins__, 'import',
-                        MagicMock(side_effect=ModuleNotFoundError))
+    monkeypatch.setitem(
+        __builtins__, "import", MagicMock(side_effect=ModuleNotFoundError)
+    )
 
     # Call the method under test
     try:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,12 +1,13 @@
 import warnings
-
+import logging
+import pytest 
 from pytest import MonkeyPatch
 from pluggy import PluginManager
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from rasa_sdk import endpoint
-from rasa_sdk.plugin import plugin_manager
-
+from rasa_sdk.plugin import plugin_manager, _discover_plugins
+logger = logging.getLogger(__name__)
 
 def test_plugin_manager() -> None:
     manager = plugin_manager()
@@ -38,3 +39,14 @@ def test_plugin_attach_sanic_app_extension(
         warnings.simplefilter("error")
         endpoint.run("actions")
     manager.hook.attach_sanic_app_extensions.assert_called_once_with(app=app_mock)
+
+def test_plugins_not_found(monkeypatch):
+    # Mock the import statement to raise ModuleNotFoundError
+    monkeypatch.setitem(__builtins__, 'import', MagicMock(side_effect=ModuleNotFoundError))
+
+    # Call the method under test
+    try:
+        import rasa_sdk_plugins
+    except ModuleNotFoundError as e:
+        # Assert the expected exception message or other details if needed
+        assert str(e) == "No module named 'rasa_sdk_plugins'"


### PR DESCRIPTION
**Proposed changes**:
- Fixes the `logger.info` when plugins not found to `logger.debug`

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
