### PR TITLE
[ATO-1661] Add `--endpoints` flag to rasa-sdk cli

### DIFF
--- a/changelog/1072.improvement.md
+++ b/changelog/1072.improvement.md
@@ -1,0 +1,1 @@
+Add an `--endpoint` flag to the rasa_sdk CLI to enable tracing configuration.

--- a/rasa_sdk/cli/arguments.py
+++ b/rasa_sdk/cli/arguments.py
@@ -57,5 +57,5 @@ def add_endpoint_arguments(parser):
     parser.add_argument(
         "--endpoints",
         default=DEFAULT_ENDPOINTS_PATH,
-        help="Configuration file for tracing as a yml file.",
+        help="Configuration file for the assistant as a yml file.",
     )

--- a/rasa_sdk/cli/arguments.py
+++ b/rasa_sdk/cli/arguments.py
@@ -1,6 +1,6 @@
 import argparse
 
-from rasa_sdk.constants import DEFAULT_SERVER_PORT
+from rasa_sdk.constants import DEFAULT_SERVER_PORT, DEFAULT_ENDPOINTS_PATH
 
 
 def action_arg(action):
@@ -53,4 +53,9 @@ def add_endpoint_arguments(parser):
         "--auto-reload",
         help="Enable auto-reloading of modules containing Action subclasses.",
         action="store_true",
+    )
+    parser.add_argument(
+        "--endpoints",
+        default=DEFAULT_ENDPOINTS_PATH,
+        help="Configuration file for tracing as a yml file.",
     )

--- a/rasa_sdk/constants.py
+++ b/rasa_sdk/constants.py
@@ -10,3 +10,4 @@ YAML_VERSION = (1, 2)
 PYTHON_LOGGING_SCHEMA_DOCS = (
     "https://docs.python.org/3/library/logging.config.html#dictionary-schema-details"
 )
+DEFAULT_ENDPOINTS_PATH = "endpoints.yml"

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,12 +1,21 @@
 import rasa_sdk.endpoint as ep
+import pytest
+
+from rasa_sdk.constants import DEFAULT_ENDPOINTS_PATH
 
 
-def test_arg_parser_endpoints():
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        ([], DEFAULT_ENDPOINTS_PATH),
+        (["--endpoints", "a.yml"], "a.yml"),
+    ],
+)
+def test_arg_parser_endpoints(args, expected):
     parser = ep.create_argument_parser()
-    args = ["--endpoints", "endpoint.yml"]
     cmdline_args = parser.parse_args(args)
-    assert cmdline_args.endpoints == "endpoint.yml"
+    assert cmdline_args.endpoints == expected
 
     help_text = parser.format_help()
     assert "--endpoints ENDPOINTS" in help_text
-    assert " Configuration file for tracing as a yml file." in help_text
+    assert " Configuration file for the assistant as a yml file." in help_text

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,0 +1,12 @@
+import rasa_sdk.endpoint as ep
+
+
+def test_arg_parser_endpoints():
+    parser = ep.create_argument_parser()
+    args = ["--endpoints", "endpoint.yml"]
+    cmdline_args = parser.parse_args(args)
+    assert cmdline_args.endpoints == "endpoint.yml"
+
+    help_text = parser.format_help()
+    assert "--endpoints ENDPOINTS" in help_text
+    assert " Configuration file for tracing as a yml file." in help_text


### PR DESCRIPTION
**Proposed changes**:
- Fixes [ATO-1661](https://rasahq.atlassian.net/browse/ATO-1661)
-
![Screenshot 2024-02-05 at 13 57 51](https://github.com/RasaHQ/rasa-sdk/assets/23738768/fc5eac32-8fb5-46af-9b4a-76f83bf4530c)


**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)


[ATO-1661]: https://rasahq.atlassian.net/browse/ATO-1661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ