### PR TITLE
[ATO-2131] Instrument ActionExecutor._create_api_response

### DIFF
--- a/changelog/1076.improvement.md
+++ b/changelog/1076.improvement.md
@@ -1,0 +1,1 @@
+Instrument `ActionExecutor._create_api_response` and extract `slots` attribute.

--- a/changelog/1076.improvement.md
+++ b/changelog/1076.improvement.md
@@ -1,1 +1,1 @@
-Instrument `ActionExecutor._create_api_response` and extract `slots` attribute.
+Instrument `ActionExecutor._create_api_response` and extract `slots`, `events`, `utters` and `message_count` attributes.

--- a/rasa_sdk/tracing/instrumentation/attribute_extractors.py
+++ b/rasa_sdk/tracing/instrumentation/attribute_extractors.py
@@ -58,7 +58,7 @@ def extract_attrs_for_validation_action(
     }
 
 
-def extract_attrs_for_create_api_response(
+def extract_attrs_for_action_executor_create_api_response(
     events: List[Dict[Text, Any]],
     messages: List[Dict[Text, Any]],
 ) -> Dict[Text, Any]:
@@ -68,5 +68,20 @@ def extract_attrs_for_create_api_response(
     :param messsages: A list of bot responses.
     :return: A dictionary containing the attributes.
     """
-    slot_names = [event.get("name") for event in events if event.get("event") == "slot"]
-    return {"slots": json.dumps(slot_names)}
+    event_names = []
+    slot_names = []
+
+    for event in events:
+        event_names.append(event.get("event"))
+        if event.get("event") == "slot" and event.get("name") != "requested_slot":
+            slot_names.append(event.get("name"))
+    utters = [
+        message.get("response") for message in messages if message.get("response")
+    ]
+
+    return {
+        "events": json.dumps(list(dict.fromkeys(event_names))),
+        "slots": json.dumps(list(dict.fromkeys(slot_names))),
+        "utters": json.dumps(utters),
+        "message_count": len(messages),
+    }

--- a/rasa_sdk/tracing/instrumentation/attribute_extractors.py
+++ b/rasa_sdk/tracing/instrumentation/attribute_extractors.py
@@ -1,6 +1,6 @@
 import json
 
-from typing import Any, Dict, Text
+from typing import Any, Dict, Text, List
 from rasa_sdk.executor import ActionExecutor, CollectingDispatcher
 from rasa_sdk.forms import ValidationAction
 from rasa_sdk.types import ActionCall, DomainDict
@@ -56,3 +56,17 @@ def extract_attrs_for_validation_action(
         "slots_to_validate": json.dumps(list(slots_to_validate)),
         "action_name": self.name(),
     }
+
+
+def extract_attrs_for_create_api_response(
+    events: List[Dict[Text, Any]],
+    messages: List[Dict[Text, Any]],
+) -> Dict[Text, Any]:
+    """Extract the attributes for `ActionExecutor.run`.
+
+    :param events: A list of events.
+    :param messsages: A list of bot responses.
+    :return: A dictionary containing the attributes.
+    """
+    slot_names = [event.get("name") for event in events if event.get("event") == "slot"]
+    return {"slots": json.dumps(slot_names)}

--- a/tests/tracing/instrumentation/conftest.py
+++ b/tests/tracing/instrumentation/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import Text
+from typing import Any, Dict, Text, List
 
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -45,6 +45,12 @@ class MockActionExecutor(ActionExecutor):
             )
 
     async def run(self, action_call: ActionCall) -> None:
+        pass
+
+    @staticmethod
+    def _create_api_response(
+        events: List[Dict[Text, Any]], messages: List[Dict[Text, Any]]
+    ) -> None:
         pass
 
 

--- a/tests/tracing/instrumentation/test_action_executor.py
+++ b/tests/tracing/instrumentation/test_action_executor.py
@@ -1,11 +1,12 @@
 import pytest
 
-from typing import Any, Dict, Sequence, Text, Optional
+from typing import Any, Dict, Sequence, Text, Optional, List
 from unittest.mock import Mock
 from pytest import MonkeyPatch
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry import trace
+from rasa_sdk.events import ActionExecuted, SlotSet
 
 from rasa_sdk.tracing.instrumentation import instrumentation
 from tests.tracing.instrumentation.conftest import MockActionExecutor
@@ -88,3 +89,46 @@ def test_instrument_action_executor_run_registers_tracer(
 
     assert tracer is not None
     assert tracer == mock_tracer
+
+
+@pytest.mark.parametrize(
+    "events, expected",
+    [
+        ([], {"slots": "[]"}),
+        ([ActionExecuted("my_form")], {"slots": "[]"}),
+        (
+            [ActionExecuted("my_form"), SlotSet("my_slot", "some_value")],
+            {"slots": '["my_slot"]'},
+        ),
+    ],
+)
+def test_tracing_action_executor_create_api_response(
+    tracer_provider: TracerProvider,
+    span_exporter: InMemorySpanExporter,
+    previous_num_captured_spans: int,
+    events: Optional[List],
+    expected: Dict[Text, Any],
+) -> None:
+    component_class = MockActionExecutor
+
+    instrumentation.instrument(
+        tracer_provider,
+        action_executor_class=component_class,
+    )
+
+    mock_action_executor = component_class()
+
+    mock_action_executor._create_api_response(events, [{"text": "hello"}])
+
+    captured_spans: Sequence[
+        ReadableSpan
+    ] = span_exporter.get_finished_spans()  # type: ignore
+
+    num_captured_spans = len(captured_spans) - previous_num_captured_spans
+    assert num_captured_spans == 1
+
+    captured_span = captured_spans[-1]
+
+    assert captured_span.name == "MockActionExecutor._create_api_response"
+
+    assert captured_span.attributes == expected

--- a/tests/tracing/instrumentation/test_action_executor.py
+++ b/tests/tracing/instrumentation/test_action_executor.py
@@ -1,6 +1,6 @@
 import pytest
 
-from typing import Any, Dict, Sequence, Text, Optional, List
+from typing import Any, Dict, Sequence, Text, Optional, List, Callable
 from unittest.mock import Mock
 from pytest import MonkeyPatch
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
@@ -16,13 +16,28 @@ from rasa_sdk.tracing.tracer_register import ActionExecutorTracerRegister
 from rasa_sdk.executor import CollectingDispatcher
 
 
-dispatcher1 = CollectingDispatcher()
-dispatcher1.utter_message(template="utter_greet")
-dispatcher2 = CollectingDispatcher()
-dispatcher2.utter_message("Hello")
-dispatcher3 = CollectingDispatcher()
-dispatcher3.utter_message("Hello")
-dispatcher3.utter_message(template="utter_greet")
+def get_dispatcher0():
+    dispatcher = CollectingDispatcher()
+    return dispatcher
+
+
+def get_dispatcher1():
+    dispatcher = CollectingDispatcher()
+    dispatcher.utter_message(template="utter_greet")
+    return dispatcher
+
+
+def get_dispatcher2():
+    dispatcher = CollectingDispatcher()
+    dispatcher.utter_message("Hello")
+    return dispatcher
+
+
+def get_dispatcher3():
+    dispatcher = CollectingDispatcher()
+    dispatcher.utter_message("Hello")
+    dispatcher.utter_message(template="utter_greet")
+    return dispatcher
 
 
 @pytest.mark.parametrize(
@@ -102,17 +117,21 @@ def test_instrument_action_executor_run_registers_tracer(
 
 
 @pytest.mark.parametrize(
-    "events, messages, expected",
+    "events, get_dispatcher, expected",
     [
-        ([], [], {"events": "[]", "slots": "[]", "utters": "[]", "message_count": 0}),
+        (
+            [],
+            get_dispatcher0,
+            {"events": "[]", "slots": "[]", "utters": "[]", "message_count": 0},
+        ),
         (
             [ActionExecuted("my_form")],
-            dispatcher2.messages,
+            get_dispatcher2,
             {"events": '["action"]', "slots": "[]", "utters": "[]", "message_count": 1},
         ),
         (
             [ActionExecuted("my_form"), SlotSet("my_slot", "some_value")],
-            dispatcher1.messages,
+            get_dispatcher1,
             {
                 "events": '["action", "slot"]',
                 "slots": '["my_slot"]',
@@ -122,7 +141,7 @@ def test_instrument_action_executor_run_registers_tracer(
         ),
         (
             [SlotSet("my_slot", "some_value")],
-            dispatcher3.messages,
+            get_dispatcher3,
             {
                 "events": '["slot"]',
                 "slots": '["my_slot"]',
@@ -137,7 +156,7 @@ def test_tracing_action_executor_create_api_response(
     span_exporter: InMemorySpanExporter,
     previous_num_captured_spans: int,
     events: Optional[List],
-    messages: Optional[List],
+    get_dispatcher: Callable,
     expected: Dict[Text, Any],
 ) -> None:
     component_class = MockActionExecutor
@@ -149,7 +168,8 @@ def test_tracing_action_executor_create_api_response(
 
     mock_action_executor = component_class()
 
-    mock_action_executor._create_api_response(events, messages)
+    dispatcher = get_dispatcher()
+    mock_action_executor._create_api_response(events, dispatcher.messages)
 
     captured_spans: Sequence[
         ReadableSpan


### PR DESCRIPTION
**Proposed changes**:
- Fixes [ATO-2131](https://rasahq.atlassian.net/browse/ATO-2131)

Views from Jaegar UI
<img width="773" alt="Screenshot 2024-02-15 at 17 49 47" src="https://github.com/RasaHQ/rasa-sdk/assets/23738768/b47833d9-6fc3-43cb-a3e8-a252b089f979">
<img width="795" alt="Screenshot 2024-02-15 at 18 18 11" src="https://github.com/RasaHQ/rasa-sdk/assets/23738768/34ccfbb0-1ee1-4a23-bdd7-e72c803f2a02">


**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)


[ATO-2131]: https://rasahq.atlassian.net/browse/ATO-2131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ