### PR TITLE
[ATO-2188] Allow access to Dialogue stack from custom actions

### DIFF
--- a/changelog/1078.improvement.md
+++ b/changelog/1078.improvement.md
@@ -1,0 +1,1 @@
+Add a `stack` property to the `Tracker` class which corresponds to the dialogue stack.

--- a/rasa_sdk/interfaces.py
+++ b/rasa_sdk/interfaces.py
@@ -33,6 +33,7 @@ class Tracker:
             state.get("followup_action"),
             state.get("active_loop", state.get("active_form", {})),
             state.get("latest_action_name"),
+            state.get("stack", []),
         )
 
     def __init__(
@@ -45,6 +46,7 @@ class Tracker:
         followup_action: Optional[Text],
         active_loop: Dict[Text, Any],
         latest_action_name: Optional[Text],
+        stack: List[Dict[Text, Any]] = [],
     ) -> None:
         """Initialize the tracker."""
 
@@ -66,6 +68,7 @@ class Tracker:
         self.latest_message = latest_message if latest_message else {}
         self.active_loop = active_loop
         self.latest_action_name = latest_action_name
+        self.stack = stack
 
     @property
     def active_form(self) -> Dict[Text, Any]:
@@ -93,6 +96,7 @@ class Tracker:
             "latest_input_channel": self.get_latest_input_channel(),
             "active_loop": self.active_loop,
             "latest_action_name": self.latest_action_name,
+            "stack": self.stack,
         }
 
     def current_slot_values(self) -> Dict[Text, Any]:
@@ -196,6 +200,7 @@ class Tracker:
             self.followup_action,
             self.active_loop,
             self.latest_action_name,
+            self.stack,
         )
 
     def last_executed_action_has(self, name: Text, skip: int = 0) -> bool:

--- a/rasa_sdk/types.py
+++ b/rasa_sdk/types.py
@@ -26,6 +26,8 @@ class TrackerState(TypedDict):
     active_form: Dict[Text, Any]
     # the name of the previously executed action or text of e2e action
     latest_action_name: Optional[Text]
+    # the current dialogue stack
+    stack: List[Dict[Text, Any]]
 
 
 class DomainDict(TypedDict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,16 @@
 from sanic import Sanic
 
 Sanic.test_mode = True
+
+
+def get_stack():
+    dialogue_stack = [
+        {
+            "frame_id": "CP6JP9GQ",
+            "flow_id": "check_balance",
+            "step_id": "0_check_balance",
+            "frame_type": "regular",
+            "type": "flow",
+        }
+    ]
+    return dialogue_stack

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -43,3 +43,16 @@ class CustomActionRaisingException(Action):
         domain: DomainDict,
     ) -> List[Dict[Text, Any]]:
         raise Exception("test exception")
+
+
+class CustomActionWithDialogueStack(Action):
+    def name(cls) -> Text:
+        return "custom_action_with_dialogue_stack"
+
+    def run(
+        self,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: DomainDict,
+    ) -> List[Dict[Text, Any]]:
+        return [SlotSet("stack", tracker.stack)]

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,9 +1,10 @@
-from typing import Dict
+from typing import Any, Dict, List, Text
 
 import pytest
 from rasa_sdk.events import SlotSet
 
 from rasa_sdk.interfaces import Tracker
+from tests.conftest import get_stack
 
 
 @pytest.mark.parametrize(
@@ -61,3 +62,22 @@ def test_tracker_with_slots():
 
     assert tracker.slots["my slot"] == 5
     assert tracker.slots["my slot 2"] is None
+
+
+@pytest.mark.parametrize(
+    "stack_state, dialogue_stack",
+    [
+        ({}, []),
+        ({"stack": get_stack()}, get_stack()),
+    ],
+)
+def test_stack_in_tracker_state(
+    stack_state: Dict[Text, Any], dialogue_stack: List[Dict[Text, Any]]
+):
+
+    state = {"events": [], "sender_id": "old", "active_loop": {}, **stack_state}
+    tracker = Tracker.from_dict(state)
+
+    assert tracker.stack == dialogue_stack
+    assert tracker.copy().stack == dialogue_stack
+    assert tracker.current_state()["stack"] == dialogue_stack

--- a/tests/tracing/test_utils.py
+++ b/tests/tracing/test_utils.py
@@ -70,7 +70,6 @@ def test_get_tracer_and_context() -> None:
     app = ep.create_app(None)
     request, _ = app.test_client.post("/webhook", data=json.dumps(data))
     tracer, context, span_name = get_tracer_and_context(None, request)
-    print(type(tracer))
 
     assert isinstance(tracer, ProxyTracer)
     assert span_name == "create_app.webhook"


### PR DESCRIPTION
**Proposed changes**:
- Fixes [ATO-2188](https://rasahq.atlassian.net/browse/ATO-2188)

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [X] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [X] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [X] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)


[ATO-2188]: https://rasahq.atlassian.net/browse/ATO-2188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ