### PR TITLE
Remove Datestamped Security Patch Image

### DIFF
--- a/.github/workflows/security-patching.yml
+++ b/.github/workflows/security-patching.yml
@@ -82,7 +82,7 @@ jobs:
         id: build
         continue-on-error: true
         run: |
-          docker build . -t ${{env.RELEASE_REGISTRY_SDK}}/rasa-sdk:${{ matrix.supported_versions }}-${{ steps.date.outputs.date }} -t ${{env.RELEASE_REGISTRY_SDK}}/rasa-sdk:${{ matrix.supported_versions }}-latest --build-arg VERSION_NUMBER=${{ matrix.supported_versions }} -f Dockerfile.patch
+          docker build . -t ${{env.RELEASE_REGISTRY_SDK}}/rasa-sdk:${{ matrix.supported_versions }}-latest --build-arg VERSION_NUMBER=${{ matrix.supported_versions }} -f Dockerfile.patch
 
       - name: Fail pushing the patch if the build is not a success
         if: steps.build.outcome == 'failure'
@@ -92,7 +92,6 @@ jobs:
       - name: Push image to release registry
         id: push
         run: |
-          docker push ${{env.RELEASE_REGISTRY_SDK}}/rasa-sdk:${{ matrix.supported_versions }}-${{ steps.date.outputs.date }}
           docker push ${{env.RELEASE_REGISTRY_SDK}}/rasa-sdk:${{ matrix.supported_versions }}-latest
  
       - name: Alert Slack if build fails


### PR DESCRIPTION
**Proposed changes**:
- Remove the datestamped security patch image to enable us to tidy up older untagged images from Artifact Registry.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
