### PR TITLE
[ATO-1652] Add target to check if gRPC code is in sync with generated python code

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Install Dependencies 📦
         run: make install
 
+      - name: Listing Dependencies 📦
+        run: poetry show
+
       - name: Lint Code 🎎
         run: |
           # If it's not a pull request, $DOCSTRING_DIFF_BRANCH is unset.


### PR DESCRIPTION
Add Makefile target to check if gRPC `.proto` files and generated Python code are in sync.
Target is part of existing `make lint` which is already part of CI.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
