### PR TITLE
Explicitly filter out Sanic warnings after Sanic is initialized

### DIFF
--- a/changelog/1120.misc.md
+++ b/changelog/1120.misc.md
@@ -1,0 +1,1 @@
+Added the functionality that resets the Sanic warnings filter, which was allowing the triggering of Sanic warnings.

--- a/changelog/1120.misc.md
+++ b/changelog/1120.misc.md
@@ -1,1 +1,1 @@
-Added the functionality that resets the Sanic warnings filter, which was allowing the triggering of Sanic warnings.
+Reset Sanic warnings filter to prevent the triggering of Sanic warnings.

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -114,6 +114,9 @@ def create_app(
     """
     app = Sanic("rasa_sdk", configure_logging=False)
 
+    # Reset Sanic warnings filter that allows the triggering of Sanic warnings
+    warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"sanic.*")
+
     configure_cors(app, cors_origins)
 
     executor = ActionExecutor()


### PR DESCRIPTION
**Proposed changes**:
- Explicitly filter out Sanic warnings after Sanic is initialized

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
