### PR TITLE
Add —actions-module argument

### DIFF
--- a/changelog/1122.improvement.md
+++ b/changelog/1122.improvement.md
@@ -1,0 +1,1 @@
+Added `--actions-module` argument for specifying the custom actions path, prioritizing it over the soon-to-be-deprecated `--actions` argument.

--- a/rasa_sdk/__main__.py
+++ b/rasa_sdk/__main__.py
@@ -25,7 +25,7 @@ def main_from_args(args):
     if args.grpc:
         asyncio.run(
             run_grpc(
-                args.actions,
+                args.actions_module or args.actions,
                 args.port,
                 args.ssl_certificate,
                 args.ssl_keyfile,
@@ -36,7 +36,7 @@ def main_from_args(args):
         )
     else:
         run(
-            args.actions,
+            args.actions_module or args.actions,
             args.port,
             args.cors,
             args.ssl_certificate,

--- a/rasa_sdk/cli/arguments.py
+++ b/rasa_sdk/cli/arguments.py
@@ -48,6 +48,12 @@ def add_endpoint_arguments(parser: argparse.ArgumentParser) -> None:
         help="name of action package to be loaded",
     )
     parser.add_argument(
+        "--actions-module",
+        type=action_arg,
+        default=None,
+        help="name of action package to be loaded",
+    )
+    parser.add_argument(
         "--ssl-keyfile",
         default=None,
         help="Set the SSL certificate to create a TLS secured server.",


### PR DESCRIPTION
**Proposed changes**:
- Added --actions-module argument to explicitly specify the path where the custom actions are stored. Should be used on priority compared to `--actions` argument that will get deprecated.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [x] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
