### PR TITLE
[ATO-2697] Stringify None attribute values to fix opentelemetry warning

### DIFF
--- a/changelog/1135.misc.md
+++ b/changelog/1135.misc.md
@@ -1,0 +1,2 @@
+Stringify `None` values for `message_id` and `sender_id` tracing tags to fix the
+`opentelemetry` warning about invalid type `NoneType` for these tags.

--- a/rasa_sdk/tracing/instrumentation/attribute_extractors.py
+++ b/rasa_sdk/tracing/instrumentation/attribute_extractors.py
@@ -25,7 +25,7 @@ def extract_attrs_for_action_executor(
     :param action_call: The `ActionCall` argument.
     :return: A dictionary containing the attributes.
     """
-    attributes = {"sender_id": action_call["sender_id"]}
+    attributes = {"sender_id": action_call.get("sender_id", "None")}
     action_name = action_call.get("next_action")
 
     if action_name:

--- a/rasa_sdk/tracing/utils.py
+++ b/rasa_sdk/tracing/utils.py
@@ -43,7 +43,7 @@ def set_span_attributes(span: Any, action_call: dict) -> None:
         "next_action": action_call.get("next_action"),
         "version": action_call.get("version"),
         "sender_id": tracker.get("sender_id"),
-        "message_id": tracker.get("latest_message", {}).get("message_id"),
+        "message_id": tracker.get("latest_message", {}).get("message_id", "None"),
     }
 
     if span.is_recording():


### PR DESCRIPTION
**Proposed changes**:
- Fixes [ATO-2697](https://rasahq.atlassian.net/browse/ATO-2697)

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [x] reformat files using `ruff` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)


[ATO-2697]: https://rasahq.atlassian.net/browse/ATO-2697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ