### PR TITLE
ENG-1235: Push release tags automatically on `rasa-sdk`

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,71 @@
+name: Tag Release Version
+on:
+  pull_request:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+.x'
+    types: [closed]
+
+env:
+  COMMIT_EMAIL: sara-tagger@users.noreply.github.com
+  DEFAULT_PYTHON_VERSION: "3.10"
+
+jobs:
+  if_merged_tag_release:
+    name: Tag Release Version
+    if: startsWith(github.head_ref, 'prepare-release-') && github.event.pull_request.merged == true
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout git repository 🕝
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          token: ${{ secrets.RELEASE_TAGGER_PAT }}
+
+      - name: Set up Python ${{ env.DEFAULT_PYTHON_VERSION }} 🐍
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+
+      - name: Read Poetry Version 🔢
+        run: |
+          echo "POETRY_VERSION=$(scripts/poetry-version.sh)" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Install poetry 🦄
+        uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
+        with:
+          poetry-version: ${{ env.POETRY_VERSION }}
+
+      - name: Load Poetry Cached Libraries ⬇
+        id: cache-poetry
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 #v4.0.0
+        with:
+          path: .venv
+          key: ${{ runner.os }}-poetry-${{ env.POETRY_VERSION }}-${{ env.DEFAULT_PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}-${{ secrets.POETRY_CACHE_VERSION }}
+          restore-keys: ${{ runner.os }}-poetry-${{ env.DEFAULT_PYTHON_VERSION }}
+
+      - name: Clear Poetry cache
+        if: steps.cache-poetry.outputs.cache-hit == 'true' && contains(github.event.pull_request.labels.*.name, 'tools:clear-poetry-cache-unit-tests')
+        run: rm -r .venv
+
+      - name: Create virtual environment
+        if: steps.cache-poetry.outputs.cache-hit != 'true' || contains(github.event.pull_request.labels.*.name, 'tools:clear-poetry-cache-unit-tests')
+        run: python -m venv create .venv
+
+      - name: Set up virtual environment
+        run: poetry config virtualenvs.in-project true
+
+      - name: Install Dependencies 📦
+        # Poetry intermittently fails to install dependency if it is not PEP 517 compliant
+        # This is a workaround for that issue
+        run: |
+          sudo apt-get -y install libpq-dev
+          make install-full
+
+      - name: Configure git
+        run: |
+          git config --global user.email ${{ env.COMMIT_EMAIL }}
+          git config --global user.name "Github Actions"
+
+      - name: Tag Release
+        run: make tag-release

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,9 @@ cleanup-generated-changelog:  ## cleanup the generated changelog
 release: ## start the release process
 	poetry run python scripts/release.py
 
+tag-release:  ## Tag a release.
+	poetry run python scripts/release.py --tag
+
 generate-grpc:  ## generate grpc code
 	 poetry run python -m grpc_tools.protoc \
 	 	-Irasa_sdk/grpc_py=./proto \

--- a/README.md
+++ b/README.md
@@ -129,15 +129,7 @@ by GitHub Actions.
 2. If this is a minor / major release: Make sure all fixes from currently supported minor versions have been merged from their respective release branches (e.g. 3.3.x) back into main.
 3. Run `make release`
 4. Create a PR against main or the release branch (e.g. `1.2.x`)
-5. Once your PR is merged, pull the release branch locally.
-6. Create a tag for a new release (this SHOULD always happen on `main` or release branches), e.g. using
-    ```bash
-    git tag 1.2.0 -m "next release"
-    git push origin 1.2.0
-    ```
-    GitHub Actions will build this tag and push a package to
-    [pypi](https://pypi.python.org/pypi/rasa-sdk).
-6. **If this is a minor release**, a new release branch should be created
+5. **If this is a minor release**, a new release branch should be created
   pointing to the same commit as the tag to allow for future patch releases,
   e.g.
     ```bash

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -37,16 +37,15 @@ RELEASE_BRANCH_PATTERN = re.compile(r"^\d+\.\d+\.x$")
 def create_argument_parser() -> argparse.ArgumentParser:
     """Parse all the command line arguments for the release script."""
 
-    parser = argparse.ArgumentParser(description="Prepare or tag the next library release")
+    parser = argparse.ArgumentParser(
+        description="Prepare or tag the next library release"
+    )
     parser.add_argument(
         "--next_version",
         type=str,
         help="Either next version number or 'major', 'minor', 'micro', 'alpha', 'rc'",
     )
-    parser.add_argument(
-        "--tag",
-        help="Tag the next release",action="store_true"
-    )
+    parser.add_argument("--tag", help="Tag the next release", action="store_true")
 
     return parser
 
@@ -318,7 +317,11 @@ def tag_release() -> None:
     """Tag the current commit with the current version."""
     print(
         """
-    The release tag script will tag the current commit with the current version."""
+    The release tag script will tag the current commit with the current version.
+
+    This should be done on the applicable *.x branch after running
+    `make release` and merging the prepared release branch.
+        """
     )
 
     branch = git_current_branch()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -3,7 +3,9 @@
 - creates a new changelog section in CHANGELOG.mdx based on all collected changes
 - increases the version number
 - pushes the new branch to GitHub
+- Tags the release and pushes tag to GitHub
 """
+
 import argparse
 import os
 import re
@@ -32,11 +34,15 @@ RELEASE_BRANCH_PATTERN = re.compile(r"^\d+\.\d+\.x$")
 def create_argument_parser() -> argparse.ArgumentParser:
     """Parse all the command line arguments for the release script."""
 
-    parser = argparse.ArgumentParser(description="prepare the next library release")
+    parser = argparse.ArgumentParser(description="Prepare or tag the next library release")
     parser.add_argument(
         "--next_version",
         type=str,
         help="Either next version number or 'major', 'minor', 'micro', 'alpha', 'rc'",
+    )
+    parser.add_argument(
+        "--tag",
+        help="Tag the next release",action="store_true"
     )
 
     return parser
@@ -284,39 +290,95 @@ def print_done_message_same_branch(version: Version) -> None:
     )
 
 
-def main(args: argparse.Namespace) -> None:
-    """Start a release preparation."""
+def tag_commit(tag: Text) -> None:
+    """Tags a git commit."""
+    print(f"Applying tag '{tag}' to commit.")
+    check_call(["git", "tag", tag, "-m", "next release"])
 
+
+def push_tag(tag: Text) -> None:
+    """Pushes a tag to the remote."""
+    print(f"Pushing tag '{tag}' to origin.")
+    check_call(["git", "push", "origin", tag, "--tags"])
+
+
+def print_tag_release_done_message(version: Version) -> None:
+    """Print final information for the user about the tagged commit."""
+    print()
     print(
         "The release script will increase the version number, "
         "create a changelog and create a release branch. Let's go!"
+        f"\033[94m Tag for version {version} "
+        "was added and pushed to the remote \033[0m"
     )
 
+
+def tag_release() -> None:
+    """Tag the current commit with the current version."""
+    print(
+        """
+    The release tag script will tag the current commit with the current version."""
+    )
+
+    branch = git_current_branch()
+    version = Version(get_current_version())
+
+    if (
+        not version.is_alpha
+        and not version.is_beta
+        and not git_current_branch_is_main_or_release()
+    ):
+        print(
+            f"""
+    You are currently on branch {branch}.
+    You should only apply release tags to release branches (e.g. 1.x) or main.
+            """
+        )
+        sys.exit(1)
     ensure_clean_git()
-    version = next_version(args)
-    confirm_version(version)
+    tag = str(version)
+    tag_commit(tag)
+    push_tag(tag)
 
-    write_version_file(version)
-    write_version_to_pyproject(version)
+    print_tag_release_done_message(version)
 
-    if not version.pre:
-        # never update changelog on a prerelease version
-        generate_changelog(version)
 
-    # alpha workflow on feature branch when a version bump is required
-    if version.is_alpha and not git_current_branch_is_main_or_release():
-        create_commit(version)
-        push_changes()
+def main(args: argparse.Namespace) -> None:
+    """Start a release preparation, or tag release."""
 
-        print_done_message_same_branch(version)
+    if not args.tag:
+        print(
+            "The release script will increase the version number, "
+            "create a changelog and create a release branch. Let's go!"
+        )
+
+        ensure_clean_git()
+        version = next_version(args)
+        confirm_version(version)
+
+        write_version_file(version)
+        write_version_to_pyproject(version)
+
+        if not version.pre:
+            # never update changelog on a prerelease version
+            generate_changelog(version)
+
+        # alpha workflow on feature branch when a version bump is required
+        if version.is_alpha and not git_current_branch_is_main_or_release():
+            create_commit(version)
+            push_changes()
+
+            print_done_message_same_branch(version)
+        else:
+            base = git_current_branch()
+            branch = create_release_branch(version)
+
+            create_commit(version)
+            push_changes()
+
+            print_done_message(branch, base, version)
     else:
-        base = git_current_branch()
-        branch = create_release_branch(version)
-
-        create_commit(version)
-        push_changes()
-
-        print_done_message(branch, base, version)
+        tag_release()
 
 
 if __name__ == "__main__":

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -3,7 +3,10 @@
 - creates a new changelog section in CHANGELOG.mdx based on all collected changes
 - increases the version number
 - pushes the new branch to GitHub
-- Tags the release and pushes tag to GitHub
+
+When run with `--tag`:
+- tags the current commit with the version number found in the version module
+- and pushes the tag to GitHub.
 """
 
 import argparse

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -306,9 +306,7 @@ def print_tag_release_done_message(version: Version) -> None:
     """Print final information for the user about the tagged commit."""
     print()
     print(
-        "The release script will increase the version number, "
-        "create a changelog and create a release branch. Let's go!"
-        f"\033[94m Tag for version {version} "
+        f"\033[94m All done - tag for version {version} "
         "was added and pushed to the remote \033[0m"
     )
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -363,8 +363,8 @@ def main(args: argparse.Namespace) -> None:
         write_version_file(version)
         write_version_to_pyproject(version)
 
-        if not version.pre:
-            # never update changelog on a prerelease version
+        if not version.pre and not version.dev:
+            # never update changelog on a prerelease or Dev version
             generate_changelog(version)
 
         # alpha workflow on feature branch when a version bump is required


### PR DESCRIPTION
**Proposed changes**:
Introduce mechanism to automatically create and push tag for release, similar to how it is already done in `rasa-private`. Summary of changes:
1. Updated `scripts/release.py` to create and push release tag, if invoked with `--tag` flag.
2. Updated `Makefile` with new target `make tag-release`.
3. Added GHA workflow `tag-release`, to do this in CI, when PR is merged to `main` or a release branch.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
-    Manually tested this locally, as described below*
- [x] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
-    Not required I think as this is internal-only change, and not user facing?
- [x] reformat files using `ruff` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)

*Ran `make release` and `make tag-release` locally, to see that a tag is created and pushed (**Note**: Tagging function checks that the branch is `main` or a final release branch (complying to regex pattern `^\d+\.\d+\.x$` for e.g. `1.2.x`), so locally disabled this check so that I can test on a dev-test release branch):

```
(rasa-sdk-py3.10) asadhasan@ENG-UK-0011 ~/r/rasa-sdk (ENG-1235-push-release-tags-automatically-on-rasa-sdk) [1]> make release && make tag-release
poetry run python scripts/release.py
The release script will increase the version number, create a changelog and create a release branch. Let's go!
? What is the version number you want to release ('major', 'minor', 'micro', 'alpha', 'rc' or valid version number e.g. '3.10.1' or '3.10.1a1')? 3.10.0dev5
? Is the next version '3.10.0.dev5' correct (current version is '3.10.0.dev4')? Yes
Loading template...
Finding news fragments...
Rendering news fragments...
Writing to newsfile...
Staging newsfile...
No news fragments to remove. Skipping!
Done!
Switched to a new branch 'prepare-release-3.10.0.dev5'
[prepare-release-3.10.0.dev5 bda721c] prepared release of version 3.10.0.dev5
 6 files changed, 33 insertions(+), 7 deletions(-)
 delete mode 100644 changelog/1122.improvement.md
 delete mode 100644 changelog/1128.misc.md
 delete mode 100644 changelog/1135.misc.md
Enumerating objects: 13, done.
Counting objects: 100% (13/13), done.
Delta compression using up to 14 threads
Compressing objects: 100% (7/7), done.
Writing objects: 100% (7/7), 813 bytes | 813.00 KiB/s, done.
Total 7 (delta 6), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (6/6), completed with 6 local objects.
remote: 
remote: Create a pull request for 'prepare-release-3.10.0.dev5' on GitHub by visiting:
remote:      https://github.com/RasaHQ/rasa-sdk/pull/new/prepare-release-3.10.0.dev5
remote: 
remote: GitHub found 11 vulnerabilities on RasaHQ/rasa-sdk's default branch (1 high, 9 moderate, 1 low). To find out more, visit:
remote:      https://github.com/RasaHQ/rasa-sdk/security/dependabot
remote: 
To https://github.com/RasaHQ/rasa-sdk.git
 * [new branch]      HEAD -> prepare-release-3.10.0.dev5

 All done - changes for version 3.10.0.dev5 are ready! 

Please open a PR on GitHub: https://github.com/RasaHQ/rasa-sdk/compare/ENG-1235-push-release-tags-automatically-on-rasa-sdk...prepare-release-3.10.0.dev5?expand=1
poetry run python scripts/release.py --tag

    The release tag script will tag the current commit with the current version.

    This should be done on the applicable *.x branch after running
    `make release` and merging the prepared release branch.
        
Applying tag '3.10.0.dev5' to commit.
Pushing tag '3.10.0.dev5' to origin.
Enumerating objects: 2, done.
Counting objects: 100% (2/2), done.
Delta compression using up to 14 threads
Compressing objects: 100% (2/2), done.
Writing objects: 100% (2/2), 304 bytes | 304.00 KiB/s, done.
Total 2 (delta 0), reused 0 (delta 0), pack-reused 0
To https://github.com/RasaHQ/rasa-sdk.git
 * [new tag]         3.10.0.dev5 -> 3.10.0.dev5
 * [new tag]         3.10.0.dev2 -> 3.10.0.dev2

 All done - tag for version 3.10.0.dev5 was added and pushed to the remote 
```
