### PR TITLE
ENG-1235: Enable triggering release-tagging workflow manually on-demand also

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -146,7 +146,7 @@ jobs:
           echo "RASA_SDK_VERSION=${RASA_SDK_VERSION/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: Notify Slack 💬
-        if: env.IS_TAG_BUILD && success()
+        if: success()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_ASSISTANT_RELEASE_WEBHOOK }}
         uses: Ilshidur/action-slack@2.1.0
@@ -154,7 +154,7 @@ jobs:
           args: "⚡ New *Rasa SDK* version ${{ env.RASA_SDK_VERSION }} has been released! Changelog: https://github.com/RasaHQ/rasa-sdk/blob/${{ env.RASA_SDK_VERSION }}/CHANGELOG.mdx"
 
       - name: Notify Slack of Failure ⛔
-        if: env.IS_TAG_BUILD && failure()
+        if: failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_ASSISTANT_DEV_TRIBE_WEBHOOK }}
         uses: Ilshidur/action-slack@2.1.0

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -5,6 +5,7 @@ on:
       - main
       - '[0-9]+.[0-9]+.x'
     types: [closed]
+  workflow_dispatch:
 
 env:
   COMMIT_EMAIL: sara-tagger@users.noreply.github.com


### PR DESCRIPTION
**Proposed changes**:
Enable triggering release-tagging workflow manually on-demand also, in case previous auto-run(s) had failed, and we want to re-run on existing `prepared-release-` branch.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
-   N/A
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
-   N/A
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
-   N/A
- [ ] reformat files using `ruff` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
-   N/A
