### PR TITLE
Do not use relpath because it doesnt work well on windows

### DIFF
--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -362,14 +362,13 @@ class ActionExecutor:
                 new_module = importlib.reload(module)
                 self._modules[path] = TimestampModule(timestamp, new_module)
                 logger.info(
-                    f"Reloaded module/package: '{module.__name__}' "
-                    f"(file: '{os.path.relpath(path)}')"
+                    f"Reloaded module/package: '{module.__name__}' (file: '{path}')"
                 )
                 any_module_reloaded = True
             except (SyntaxError, ImportError):
                 logger.exception(
                     f"Error while reloading module/package: '{module.__name__}' "
-                    f"(file: '{os.path.relpath(path)}'):"
+                    f"(file: '{path}'):"
                 )
                 logger.info("Please fix the error(s) in the Python file and try again.")
 


### PR DESCRIPTION
**Proposed changes**:
- Do not use relpath because it doesnt work well on windows; it caused a failure in Rasa Pro CI windows tests, see [this PR](https://github.com/RasaHQ/rasa-private/pull/1778)

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `ruff` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
