### PR TITLE
Change AWS region for DEV docker images to eu

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   IS_TAG_BUILD: ${{ startsWith(github.event.ref, 'refs/tags') }}
-  DEV_REPOSITORY: 329710836760.dkr.ecr.us-east-1.amazonaws.com/rasa-sdk-dev
-  AWS_REGION: us-east-1
+  DEV_REPOSITORY: 329710836760.dkr.ecr.eu-west-1.amazonaws.com/rasa/rasa-sdk-dev
+  AWS_REGION: eu-west-1
   # This tag is used to build the image without dev dependencies
   DEV_IMAGE_TAG: pr${{ github.event.number }}
   # This tag is used to build the image with dev dependencies

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -4,7 +4,7 @@ on:
     types: [closed]
 
 env:
-  AWS_REGION: us-east-1
+  AWS_REGION: eu-west-1
 
 permissions:
   id-token: write # This is required for requesting the JWT


### PR DESCRIPTION
- Rasa Pro CI cluster will be in eu-west-1, so wee need to keep the images in the same zone to avoid additional fees
- Change AWS region for DEV docker images to eu-west-1

