### PR TITLE
Update `pypa/gh-action-pypi-publish` to try fix release failure

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -130,9 +130,9 @@ jobs:
         run: poetry build
 
       - name: Publish to PyPI 📦
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
-          skip_existing: true
+          skip-existing: true
 
   release-atifacts-publish-release:
     name: Release Artifacts Publish Release


### PR DESCRIPTION
**Proposed changes**:
With previous version, releases were failing with failure:
```
Warning:  It looks like you are trying to use an API token to authenticate in the package index and your token value does not start with "pypi-" as it typically should. This may cause an authentication error. Please verify that you have copied your token properly if such an error occurs.
...
ERROR    HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/
         Forbidden
```
Runs successful after upgrade:
https://github.com/RasaHQ/rasa-sdk/actions/runs/27946339498/job/82691988864
https://github.com/RasaHQ/rasa-sdk/actions/runs/27946311071/job/82691889988

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `ruff` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
