### PR TITLE
[INFRA-1967] Workflow security hardening

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -159,7 +159,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RASASDK_GITHUB_TOKEN }}
         run: |
           GITHUB_TAG=$GITHUB_TAG
-          pip install -U github3.py pep440-version-utils
+          pip install github3.py==4.0.1 pep440-version-utils==1.2.0
           python3 scripts/publish_gh_release_notes.py
 
   release-artifact-slack-notifications:

--- a/.github/workflows/security-patching.yml
+++ b/.github/workflows/security-patching.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
           repository: RasaHQ/get-release-records-from-cms-gha
-          ref: main
+          ref: 822cff242ec228aa365a40c2bd0c5ace5599684e
           token: ${{ secrets.CLONE_CMS_CHECKER }}
           path: .github/get-release-records-from-cms-gha
 


### PR DESCRIPTION
[JIRA](https://rasahq.atlassian.net/browse/INFRA-1967)

- Pin github3.py to 4.0.1 and pep440-version-utils to 1.2.0
in the release-atifacts-publish-release job, which runs with
contents: write and access to RASASDK_GITHUB_TOKEN.

- ref to SHA instead of branch in `RasaHQ/get-release-records-from-cms-gha`