### PR TITLE
Bump pypa/gh-action-pypi-publish to v1.13.0 on 3.15.x (fix PyPI publish 403)

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -130,7 +130,7 @@ jobs:
         run: poetry build
 
       - name: Publish to PyPI 📦
-        uses: pypa/gh-action-pypi-publish@bea5cda687c2b79989126d589ef4411bedce0195
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           skip_existing: true
 


### PR DESCRIPTION
**Proposed changes**:
- Bump `pypa/gh-action-pypi-publish` on the `3.15.x` release workflow from the old, untagged pin `bea5cda6…` to `ed0c539…` (**v1.13.0**), matching the pin already in use on `3.16.x`.

**Why**:
The `3.15.3` release ran to completion for the Docker + tag steps, but the **Release Artifacts PyPI** job failed with `403 Forbidden` from `upload.pypi.org` (with a warning that the token "does not start with `pypi-`"). The pinned action SHA predates working PyPI **Trusted Publishing (OIDC)** support, so it falls back to token auth and is rejected — so `rasa-sdk 3.15.3` did not publish to PyPI.

This is the same failure that was already fixed on `main` (["Update `pypa/gh-action-pypi-publish` to try fix release failure"](https://github.com/RasaHQ/rasa-sdk/pull/1349)) and is present on `3.16.x` (`v1.13.0`) and `main` (`v1.14.0`) — it was simply never backported to `3.15.x`. Diffing the workflow across branches, this action pin is the only difference between `3.15.x` and `3.16.x`; `3.16.3` published successfully with `v1.13.0` + `skip_existing: true` (kept unchanged here).

**Follow-up**: after merge, the existing `3.15.3` tag can be re-published by re-running `release-artifacts.yml` via `workflow_dispatch` (`tag_version: 3.15.3`) from the `3.15.x` branch.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [x] reformat files using `ruff` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
