### PR TITLE
[ENG-2854] Enable Renovate for poetry dependency updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG SETUPTOOLS_VERSION=82.0.1
 # Minimum pip version
 ARG PIP_MIN_VERSION=26.1
 # Recompute with: curl -fsSL https://bootstrap.pypa.io/get-pip.py | sha256sum
-ARG GET_PIP_SHA256=a341e1a43e38001c551a1508a73ff23636a11970b61d901d9a1cad2a18f57055
+ARG GET_PIP_SHA256=25b5c39ade96bab5eabe6404ce83cab6da2deb5fe3c07d9881f43803edb6f9c8
 
 FROM ubuntu:22.04 AS base
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,4 +1,4 @@
-// Renovate configuration for rasa-sdk (Studio/rasa-private-adapted, poetry-only).
+// Renovate configuration for rasa-sdk (Studio-adapted, poetry-only).
 // Groups all minor/patch updates into a single PR,
 // proposed 3 times during work week, after a 3-day supply-chain release cooldown.
 // Skips majors, 0.x (unstable) packages.
@@ -7,8 +7,6 @@
 // cooldown. They may still be constrained by packageRules below (e.g. majors /
 // 0.x disabled) unless Renovate's vulnerability path overrides those rules.
 // ENG-2854 / epic PF-1454. Dependabot remains until PF-1465.
-// Org-level Mend config supplies GitHub auth + FontAwesome token for onboarded
-// repos — no per-repo InfraSec ticket or hostRules needed here.
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended"],

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,61 @@
+// Renovate configuration for rasa-sdk (Studio/rasa-private-adapted, poetry-only).
+// Groups all minor/patch updates into a single PR,
+// proposed 3 times during work week, after a 3-day supply-chain release cooldown.
+// Skips majors, 0.x (unstable) packages.
+// Security (vulnerability-alert) updates are grouped, labeled
+// "type:vulnerabilities", and bypass the schedule, but keep the same 3-day
+// cooldown. They may still be constrained by packageRules below (e.g. majors /
+// 0.x disabled) unless Renovate's vulnerability path overrides those rules.
+// ENG-2854 / epic PF-1454. Dependabot remains until PF-1465.
+// Org-level Mend config supplies GitHub auth + FontAwesome token for onboarded
+// repos — no per-repo InfraSec ticket or hostRules needed here.
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:recommended"],
+  baseBranchPatterns: [
+    "main",
+    "3.18.x",
+    "3.17.x",
+    "3.16.x",
+    "3.15.x", // drop after EoSM 2026-08-26
+  ],
+  enabledManagers: ["poetry"],
+  minimumReleaseAge: "3 days",
+  schedule: [
+    "before 4am on Monday",
+    "before 4am on Wednesday",
+    "before 4am on Friday",
+  ],
+  timezone: "UTC",
+  prConcurrentLimit: 7,
+  vulnerabilityAlerts: {
+    groupName: "security updates",
+    groupSlug: "security",
+    minimumReleaseAge: "3 days",
+    vulnerabilityFixStrategy: "lowest",
+    labels: ["type:vulnerabilities"],
+    automerge: true,
+  },
+  packageRules: [
+    {
+      matchUpdateTypes: ["major"],
+      enabled: false,
+    },
+    {
+      matchManagers: ["poetry"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "all poetry dependencies",
+      groupSlug: "all-poetry",
+      automerge: true,
+    },
+    {
+      // Skip packages still on 0.x versions: semver allows breaking changes
+      // in any 0.x release, so these need manual review instead.
+      matchCurrentVersion: "<1.0.0",
+      enabled: false,
+    },
+  ],
+  labels: ["type:dependencies"],
+  rangeStrategy: "pin",
+  semanticCommits: "disabled",
+}


### PR DESCRIPTION
**Proposed changes**:
- Add root `renovate.json5` to onboard `rasa-sdk` to the shared Studio Renovate pattern ([ENG-2854](https://rasahq.atlassian.net/browse/ENG-2854), epic [PF-1454](https://rasahq.atlassian.net/browse/PF-1454)).
- Poetry only (`enabledManagers: ["poetry"]`): no npm/`package.json` in this repo. 3-day cooldown, Mon/Wed/Fri schedule, grouped minor/patch + security, skip majors/0.x.
- **Base branches** (`main`, `3.18.x`–`3.15.x`): chosen from rasa-sdk release lines still within the commercial 9-month End of Software Maintenance window ([release & maintenance policy](https://rasa.com/rasa-product-release-and-maintenance-policy) — associated packages). Dates come from each SDK `x.y.0` tag (which lockstep with Rasa Pro initial release dates). Drop `3.15.x` after EoSM **2026-08-26**. `3.14.x` and older are past EoSM.
- No per-repo InfraSec ticket for GitHub PAT: org-level Mend config already supplies GitHub auth for onboarded repos.
- Dependabot stays until [PF-1465](https://rasahq.atlassian.net/browse/PF-1465).
- **Also refresh `GET_PIP_SHA256` in `Dockerfile`.** The pin guards `https://bootstrap.pypa.io/get-pip.py`, which is unversioned and regenerated on pip releases. After **pip 26.2**, the old hash no longer matched, so **Build dev Docker image** failed on every PR (including this one). Updating the pin here matches how this repo usually handles dependency/bootstrap churn — as part of a maintenance batch (e.g. PF-1229 / PF-1492), not as a standalone checksum-only PR. Same stale pin remains on `3.16.x`–`3.18.x` (backports follow separately if needed). Closed the abandoned standalone attempt in #1375.

### Known limitation — Mend Silent mode
Mend Dependency Updates may remain Silent until flipped Interactive. This PR lands config only; live PRs / Dependency Dashboard are a follow-up after the Mend GitHub App has access to `RasaHQ/rasa-sdk`.

**Security scan:** Snyk Code skipped — changes are JSON5 config + a Dockerfile `ARG` pin (no first-party Python/TS/JS).

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions) — skipped: internal tooling / Renovate config + CI build pin only
- [ ] reformat files using `ruff` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)

[ENG-2854]: https://rasahq.atlassian.net/browse/ENG-2854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PF-1454]: https://rasahq.atlassian.net/browse/PF-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PF-1465]: https://rasahq.atlassian.net/browse/PF-1465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ