### PR TITLE
[ENG-2914] Set up auto-backporting PRs on Rasa SDK

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,23 @@
+{
+  "repoOwner": "RasaHQ",
+  "repoName": "rasa-sdk",
+  "targetBranchChoices": [
+    "main",
+    "3.12.x",
+    "3.13.x",
+    "3.14.x",
+    "3.15.x",
+    "3.16.x",
+    "3.17.x",
+    "3.18.x"
+  ],
+  "commitConflicts": true,
+  "branchLabelMapping": {
+    "^backport-to-(.+)$": "$1"
+  },
+  "prTitle": "Backport PR #{{sourcePullRequest.number}} '{{sourcePullRequest.title}}' to {{targetBranch}}",
+  "prDescription": "This PR was created by the Backporting workflow.\n\nSource PR description:\n{{defaultPrDescription}}.",
+  "publishStatusCommentOnSuccess": true,
+  "publishStatusCommentOnFailure": true,
+  "backportBranchName": "backport-pr-{{sourcePullRequest.number}}-to-{{targetBranch}}"
+}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,35 @@
+name: Automatic backport action
+
+on:
+  pull_request_target:
+    types: ["labeled", "closed"]
+
+jobs:
+  backport:
+    name: Backport PR
+    # Only run when a backport target was requested. Merged PRs without a
+    # backport-to-* label skip cleanly instead of failing with no-branches-exception.
+    if: >
+      github.event.pull_request.merged == true
+      && !(contains(github.event.pull_request.labels.*.name, 'backport'))
+      && contains(join(github.event.pull_request.labels.*.name, ','), 'backport-to-')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Backport Action
+        uses: sorenlouv/backport-github-action@ad888e978060bc1b2798690dd9d03c4036560947  #v.9.5.1
+        with:
+          github_token: ${{ secrets.RASASDK_GITHUB_TOKEN }}
+          auto_backport_label_prefix: backport-to-
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log


### PR DESCRIPTION
**Proposed changes**:
- Add automatic backporting of merged PRs to supported release branches ([ENG-2914](https://rasahq.atlassian.net/browse/ENG-2914)), mirroring the rasa-private setup from [ATO-2862](https://rasahq.atlassian.net/browse/ATO-2862) / [rasa-private#1367](https://github.com/RasaHQ/rasa-private/pull/1367).
- `.github/workflows/backport.yml` — on merge + `backport-to-*` label, opens backport PRs via `sorenlouv/backport-github-action`.
- `.backportrc.json` — label→branch mapping and targets: `main`, `3.12.x`…`3.18.x`.
- Uses `RASASDK_GITHUB_TOKEN` and `ubuntu-24.04` + existing harden-runner pin (repo conventions vs rasa-private’s `RASABOT` / Warp runners).
- Changelog skipped (internal CI tooling).
- Post-merge validation still required for ticket AC: label a merged PR `backport-to-<branch>` and confirm a backport PR opens.
- **Security scan:** Snyk Code skipped — workflow YAML + JSON config only (no first-party Python/TS/JS).

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `ruff` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)

Made with [Cursor](https://cursor.com)

[ENG-2914]: https://rasahq.atlassian.net/browse/ENG-2914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ATO-2862]: https://rasahq.atlassian.net/browse/ATO-2862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ