### PR TITLE
[ENG-2916] Auto-release prepare path after Renovate merge on 3.N.x

### DIFF
--- a/.github/workflows/auto_release_renovate.yml
+++ b/.github/workflows/auto_release_renovate.yml
@@ -1,0 +1,285 @@
+# Auto-release after a Renovate dependency PR is merged into a supported
+# SDK release line (`3.N.x`).
+#
+# Live flow:
+# 1. Detect merged Renovate PR on `3.N.x` (never `main`).
+# 2. Dedupe if an open prepare-release-* PR already targets that base.
+# 3. Run `scripts/release.py --next_version` for the next micro/patch.
+# 4. Open `prepare-release-<version>` as rasabot via `gh pr create`.
+# 5. Human reviews and merges; `release.yml` tags on merge.
+#
+# v1 human gate: the prepare PR stays open until a person merges it.
+# Auto-merge of prepare PRs is out of scope for now.
+#
+# Security (pull_request_target):
+# - Job only runs for merged renovate[bot] PRs with renovate/ heads onto *.x.
+# - Checkout is always the base branch (trusted), never the PR head.
+# - Mutating git / opening the PR uses RASASDK_GITHUB_TOKEN.
+
+name: Auto Release Renovate
+
+on:
+  pull_request_target:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      base_branch:
+        description: >
+          Supported SDK release line to target (e.g. 3.16.x). Must match
+          ^[0-9]+.[0-9]+.x$ — never main.
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  # Serialize per base branch so the dedupe step can't race a concurrent prepare;
+  # never cancel an in-flight prepare (it pushes a branch before opening the PR).
+  group: auto-release-renovate-${{ github.event.pull_request.base.ref || inputs.base_branch || github.ref }}
+  cancel-in-progress: false
+
+env:
+  DEFAULT_PYTHON_VERSION: "3.10"
+  RELEASE_BRANCH_PATTERN: '^[0-9]+\.[0-9]+\.x$'
+
+jobs:
+  prepare-auto-release:
+    name: Prepare patch after Renovate
+    runs-on: ubuntu-24.04
+    # Live path: only merged Renovate PRs onto a *.x base. Dispatch always runs.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.action == 'closed' &&
+        github.event.pull_request.merged == true &&
+        startsWith(github.event.pull_request.head.ref, 'renovate/') &&
+        github.event.pull_request.user.login == 'renovate[bot]' &&
+        endsWith(github.event.pull_request.base.ref, '.x')
+      )
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Resolve base branch
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_BASE_BRANCH: ${{ inputs.base_branch }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -eu
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            base_branch="${INPUT_BASE_BRANCH}"
+          else
+            base_branch="${PR_BASE_REF}"
+          fi
+
+          # Reject newlines before writing GITHUB_OUTPUT (Actions output injection).
+          case "${base_branch}" in
+            *$'\n'*|*$'\r'*)
+              echo "::error::base_branch must not contain newlines"
+              exit 1
+              ;;
+          esac
+
+          printf 'base_branch=%s\n' "${base_branch}" >> "$GITHUB_OUTPUT"
+          echo "Resolved base_branch=${base_branch} (event=${EVENT_NAME})"
+
+      - name: Validate base branch
+        id: validate
+        env:
+          BASE_BRANCH: ${{ steps.resolve.outputs.base_branch }}
+          RELEASE_BRANCH_PATTERN: ${{ env.RELEASE_BRANCH_PATTERN }}
+        run: |
+          set -eu
+
+          if [[ -z "${BASE_BRANCH}" ]]; then
+            echo "::error::base_branch is required"
+            exit 1
+          fi
+
+          if [[ "${BASE_BRANCH}" == "main" ]]; then
+            echo "::error::Auto-release must never target main."
+            exit 1
+          fi
+
+          if [[ "${BASE_BRANCH}" == prepare-release-* ]]; then
+            echo "::error::base_branch must be a release line (N.N.x), not a prepare-release head."
+            exit 1
+          fi
+
+          if ! [[ "${BASE_BRANCH}" =~ ${RELEASE_BRANCH_PATTERN} ]]; then
+            echo "::error::base_branch '${BASE_BRANCH}' does not match ${RELEASE_BRANCH_PATTERN}"
+            exit 1
+          fi
+
+          echo "Base branch '${BASE_BRANCH}' is valid."
+
+      # Always checkout the trusted base branch — never the Renovate PR head.
+      - name: Checkout base branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ steps.resolve.outputs.base_branch }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Dedupe open prepare-release PRs
+        id: dedupe
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BASE_BRANCH: ${{ steps.resolve.outputs.base_branch }}
+        run: |
+          set -euo pipefail
+
+          prepare_prs="$(
+            gh pr list \
+              --base "${BASE_BRANCH}" \
+              --state open \
+              --json number,url,title,headRefName \
+              --jq '[.[] | select(.headRefName | startswith("prepare-release-"))]'
+          )"
+
+          prepare_count="$(echo "${prepare_prs}" | jq 'length')"
+
+          echo "Open prepare-release-* PRs on ${BASE_BRANCH}: ${prepare_count}"
+          echo "${prepare_prs}" | jq -r '.[] | "  - #\(.number) \(.headRefName) \(.url)"' || true
+
+          if [[ "${prepare_count}" -gt 0 ]]; then
+            printf 'skip=%s\n' "true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Dedupe hit — skipping prepare while an open prepare-release-* PR targets ${BASE_BRANCH}."
+          else
+            printf 'skip=%s\n' "false" >> "$GITHUB_OUTPUT"
+            echo "No conflicting open prepare-release PRs; prepare may proceed."
+          fi
+
+      - name: Get current version
+        id: get-current-version
+        if: steps.dedupe.outputs.skip != 'true'
+        shell: python
+        run: |
+          import os
+          import re
+          from pathlib import Path
+
+          text = Path("rasa_sdk/version.py").read_text(encoding="utf-8")
+          match = re.search(r'__version__\s*=\s*"([^"]+)"', text)
+          if not match:
+              raise SystemExit("Could not parse __version__ from rasa_sdk/version.py")
+          current_version = match.group(1)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as github_output:
+              github_output.write(f"current_version={current_version}\n")
+
+      - name: Get next version
+        id: get-next-version
+        if: steps.dedupe.outputs.skip != 'true'
+        env:
+          CURRENT_VERSION: ${{ steps.get-current-version.outputs.current_version }}
+        shell: python
+        run: |
+          import os
+
+          version = os.environ["CURRENT_VERSION"]
+          parts = version.split(".")
+          if len(parts) < 3 or not all(part.isdigit() for part in parts[:3]):
+              raise SystemExit(
+                  f"Expected stable X.Y.Z on release line, got '{version}'"
+              )
+          major, minor, micro = (int(parts[0]), int(parts[1]), int(parts[2]))
+          next_version = f"{major}.{minor}.{micro + 1}"
+          prepare_branch = f"prepare-release-{next_version}"
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as github_output:
+              github_output.write(f"next_version={next_version}\n")
+              github_output.write(f"prepare_branch={prepare_branch}\n")
+
+      - name: Prepare release plan
+        id: plan
+        if: steps.dedupe.outputs.skip != 'true'
+        env:
+          BASE_BRANCH: ${{ steps.resolve.outputs.base_branch }}
+          CURRENT_VERSION: ${{ steps.get-current-version.outputs.current_version }}
+          NEXT_VERSION: ${{ steps.get-next-version.outputs.next_version }}
+          PREPARE_BRANCH: ${{ steps.get-next-version.outputs.prepare_branch }}
+        run: |
+          set -eu
+          echo "Prepare plan for ${BASE_BRANCH}:"
+          echo "  current_version=${CURRENT_VERSION}"
+          echo "  next_version=${NEXT_VERSION}"
+          echo "  prepare_branch=${PREPARE_BRANCH}"
+
+      - name: Setup Python Environment
+        if: steps.dedupe.outputs.skip != 'true'
+        uses: ./.github/actions/setup-python-env
+        with:
+          PYTHON_VERSION: ${{ env.DEFAULT_PYTHON_VERSION }}
+
+      # setup-python-env installs main deps only; towncrier (dev dep) is needed by release prepare.
+      - name: Install towncrier for changelog generation
+        if: steps.dedupe.outputs.skip != 'true'
+        run: poetry run pip install "towncrier~=25.8.0"
+
+      - name: Prepare the release
+        if: steps.dedupe.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RASASDK_GITHUB_TOKEN }}
+          NEXT_VERSION: ${{ steps.get-next-version.outputs.next_version }}
+        run: |
+          set -eu
+          # Authenticate only the mutating git operation as rasabot.
+          gh auth setup-git
+          git config user.name "rasabot"
+          git config user.email "rasabot@rasa.com"
+          # Creates prepare-release-<version>, bumps version/changelog, pushes.
+          poetry run python scripts/release.py --next_version "${NEXT_VERSION}"
+
+      - name: Open prepare-release pull request
+        if: steps.dedupe.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RASASDK_GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BASE_BRANCH: ${{ steps.resolve.outputs.base_branch }}
+          NEXT_VERSION: ${{ steps.get-next-version.outputs.next_version }}
+          PREPARE_BRANCH: ${{ steps.get-next-version.outputs.prepare_branch }}
+          EVENT_NAME: ${{ github.event_name }}
+          RENOVATE_PR: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -eu
+
+          body="**Automated prepare-release after Renovate.**
+
+          - Base: \`${BASE_BRANCH}\`
+          - Version: \`${NEXT_VERSION}\`
+          - Trigger: \`${EVENT_NAME}\`
+          "
+
+          if [[ -n "${RENOVATE_PR}" && "${EVENT_NAME}" == "pull_request_target" ]]; then
+            body+=$'\n'"- Renovate PR: ${RENOVATE_PR}"
+          fi
+
+          body+=$'\n\n'"Please review CI, then approve and merge. Tagging/publish runs via the existing Release workflow after merge."
+
+          pr_url="$(
+            gh pr create \
+              --base "${BASE_BRANCH}" \
+              --head "${PREPARE_BRANCH}" \
+              --title "Release ${NEXT_VERSION}" \
+              --body "${body}"
+          )"
+
+          echo "Opened prepare PR: ${pr_url}"
+          echo "::notice::Opened ${pr_url} — human merge required before tag/publish."
+
+      - name: Skipped due to dedupe
+        if: steps.dedupe.outputs.skip == 'true'
+        run: |
+          set -eu
+          echo "Job finished without prepare because an open prepare-release-* PR already targets this base."

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG SETUPTOOLS_VERSION=82.0.1
 # Minimum pip version
 ARG PIP_MIN_VERSION=26.1
 # Recompute with: curl -fsSL https://bootstrap.pypa.io/get-pip.py | sha256sum
-ARG GET_PIP_SHA256=25b5c39ade96bab5eabe6404ce83cab6da2deb5fe3c07d9881f43803edb6f9c8
+ARG GET_PIP_SHA256=fb24e693bab954209a063d90953621412ccad4a500905a726286e038f508ddf6
 
 FROM ubuntu:22.04 AS base
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,25 @@ by GitHub Actions.
     git push origin 1.2.x
     ```
 
+### Auto patch after Renovate (supported `3.N.x` lines)
+
+When a Renovate dependency PR is merged into a supported SDK release line (`3.N.x`, never `main`),
+[Auto Release Renovate](.github/workflows/auto_release_renovate.yml) prepares the next micro/patch
+(via `scripts/release.py`) and opens a `prepare-release-<version>` PR against that same line.
+
+**Operator steps:**
+
+1. Confirm the prepare PR appeared (Actions also supports manual `workflow_dispatch` with
+   `base_branch` like `3.16.x` if you need to re-run).
+2. Review CI, changelog, and version on the prepare PR.
+3. Approve and merge it yourself.
+4. Existing [Release workflow](.github/workflows/release.yml) tags on `prepare-release-*` merge; publish
+   continues as usual.
+
+If an open `prepare-release-*` already targets that `3.N.x`, further Renovate merges on the same line
+do not open another competing prepare PR. Manual `make release` / Release workflow dispatch remains
+available. Merges to `main` and non-Renovate merges on `3.N.x` do not start this path.
+
 ## License
 Licensed under the Apache License, Version 2.0. Copyright 2021 Rasa
 Technologies GmbH. [Copy of the license](LICENSE.txt).


### PR DESCRIPTION
**Proposed changes**:
- [ENG-2916](https://rasahq.atlassian.net/browse/ENG-2916): after a Renovate dependency PR merges into a supported SDK release line (`3.N.x`, never `main`), open the next micro `prepare-release-*` PR for a human to merge; existing `release.yml` then tags/publishes.
- Add `auto_release_renovate.yml`: `pull_request_target` on merged `renovate[bot]` + `renovate/` heads onto `*.x`, plus optional `workflow_dispatch` with `base_branch`.
- Checkout the trusted base branch only; dedupe while an open `prepare-release-*` already targets that base; run `scripts/release.py --next_version` and open the prepare PR via `gh pr create` with `RASASDK_GITHUB_TOKEN`.
- Document the operator flow under README “Steps to release”.
- PR for rasa-private is here for reference: https://rasahq.atlassian.net/browse/ENG-2915 (merged)

**How to test**
- After merge: wait for a real Renovate merge onto a supported `3.N.x`
- Confirm a `prepare-release-*` PR opens as rasabot (no auto-merge)
- Confirm a second Renovate merge on the same line dedupes while that prepare PR is open
- Confirm `main` / non-Renovate merges do not trigger
- After human merge of the prepare PR, confirm existing Release tag/publish still runs

**Rollout / risk**
- Privileged `pull_request_target` scoped by narrow `if:` + base-only checkout.
- Snyk code scan: N/A (workflow YAML + README; no first-party Python/TS product code).
- Rollback: disable/revert this workflow; manual release remains.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation *(operator note in this repo's README)*
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `ruff` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)

[ENG-2916]: https://rasahq.atlassian.net/browse/ENG-2916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ