### PR TITLE
Fix Sanic AppLoader factory pickling crash on action-server startup

### DIFF
--- a/changelog/1388.bugfix.md
+++ b/changelog/1388.bugfix.md
@@ -1,0 +1,1 @@
+The action server no longer exits on startup after upgrading to Sanic 25: the app factory and SSL settings are now picklable so worker processes can spawn correctly.

--- a/rasa_sdk/endpoint.py
+++ b/rasa_sdk/endpoint.py
@@ -5,8 +5,7 @@ import warnings
 import zlib
 import json
 from functools import partial
-from typing import List, Text, Union, Optional, Any
-from ssl import SSLContext
+from typing import Dict, List, Text, Union, Optional, Any
 
 from multidict import MultiDict
 from sanic import Sanic, response
@@ -62,22 +61,20 @@ def configure_cors(
     )
 
 
-def create_ssl_context(
+def create_ssl_config(
     ssl_certificate: Optional[Text],
     ssl_keyfile: Optional[Text],
     ssl_password: Optional[Text] = None,
-) -> Optional[SSLContext]:
-    """Create a SSL context if a certificate is passed."""
-    if ssl_certificate:
-        import ssl
+) -> Optional[Dict[Text, Optional[Text]]]:
+    """Create a Sanic SSL config if a certificate is passed.
 
-        ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
-        ssl_context.load_cert_chain(
-            ssl_certificate, keyfile=ssl_keyfile, password=ssl_password
-        )
-        return ssl_context
-    else:
+    Returns cert and key paths rather than an ``ssl.SSLContext`` so each spawned
+    worker can rebuild the context; ``SSLContext`` objects are not picklable.
+    """
+    if not ssl_certificate:
         return None
+
+    return {"cert": ssl_certificate, "key": ssl_keyfile, "password": ssl_password}
 
 
 def create_argument_parser():
@@ -212,6 +209,32 @@ def create_app(
     return app
 
 
+def create_app_for_serve(
+    action_executor: ActionExecutor,
+    cors_origins: Union[Text, List[Text], None] = "*",
+    auto_reload: bool = False,
+    endpoints: str = DEFAULT_ENDPOINTS_PATH,
+    keep_alive_timeout: int = DEFAULT_KEEP_ALIVE_TIMEOUT,
+) -> Sanic:
+    """Build a Sanic app for the primary process and each worker.
+
+    Must be module-level so ``Sanic.serve`` can pickle it via ``AppLoader``.
+    """
+    app = create_app(
+        action_executor,
+        cors_origins=cors_origins,
+        auto_reload=auto_reload,
+    )
+    app.config.KEEP_ALIVE_TIMEOUT = keep_alive_timeout
+    app.register_listener(
+        partial(load_tracer_provider, endpoints),
+        "before_server_start",
+    )
+    logger.info("Starting plugins...")
+    plugin_manager().hook.attach_sanic_app_extensions(app=app)
+    return app
+
+
 def run(
     action_executor: ActionExecutor,
     port: int = DEFAULT_SERVER_PORT,
@@ -226,28 +249,20 @@ def run(
     """Starts the action endpoint server with given config values."""
     logger.info("Starting action endpoint server...")
 
-    def _app_factory() -> Sanic:
-        """Build a Sanic app for the primary process and each worker."""
-        app = create_app(
+    loader = AppLoader(
+        factory=partial(
+            create_app_for_serve,
             action_executor,
             cors_origins=cors_origins,
             auto_reload=auto_reload,
+            endpoints=endpoints,
+            keep_alive_timeout=keep_alive_timeout,
         )
-        app.config.KEEP_ALIVE_TIMEOUT = keep_alive_timeout
-        app.register_listener(
-            partial(load_tracer_provider, endpoints),
-            "before_server_start",
-        )
-        logger.info("Starting plugins...")
-        # Attach additional sanic extensions: listeners, middleware and routing
-        plugin_manager().hook.attach_sanic_app_extensions(app=app)
-        return app
-
-    loader = AppLoader(factory=_app_factory)
+    )
     app = loader.load()
 
-    ssl_context = create_ssl_context(ssl_certificate, ssl_keyfile, ssl_password)
-    protocol = "https" if ssl_context else "http"
+    ssl_config = create_ssl_config(ssl_certificate, ssl_keyfile, ssl_password)
+    protocol = "https" if ssl_config else "http"
     host = os.environ.get("SANIC_HOST", "0.0.0.0")
 
     logger.info(f"Action endpoint is up and running on {protocol}://{host}:{port}")
@@ -257,7 +272,7 @@ def run(
     app.prepare(
         host=host,
         port=port,
-        ssl=ssl_context,
+        ssl=ssl_config,
         workers=utils.number_of_sanic_workers(),
     )
     Sanic.serve(primary=app, app_loader=loader)

--- a/rasa_sdk/executor.py
+++ b/rasa_sdk/executor.py
@@ -432,6 +432,12 @@ class ActionExecutor:
         self.domain: Optional[Dict[Text, Any]] = None
         self.domain_digest: Optional[Text] = None
 
+    def __getstate__(self) -> Dict[Text, Any]:
+        """Drop unpicklable module objects so Sanic can spawn workers."""
+        state = self.__dict__.copy()
+        state["_modules"] = {}
+        return state
+
     def register_action(self, action: Union[Type[Action], Action]) -> None:
         """Register an action with the executor.
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -12,10 +12,19 @@ from sanic.http.tls.context import SanicSSLContext
 
 import rasa_sdk.endpoint as ep
 from rasa_sdk.events import SlotSet
+from rasa_sdk.plugin import plugin_manager
 from tests.conftest import get_stack
 
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_manager_cache() -> Any:
+    """Keep the cached plugin manager from leaking into other test modules."""
+    yield
+    plugin_manager.cache_clear()
+
 
 # Shared by gRPC TLS integration tests; reused here for HTTPS startup pickling.
 _SSL_CERT = Path("integration_tests/grpc_server/setup/certs/server.pem")
@@ -237,10 +246,10 @@ def test_run_ssl_config_is_picklable(
 ) -> None:
     """Sanic.serve pickles server SSL settings when spawning workers.
 
-    A live ``ssl.SSLContext`` from ``create_ssl_context()`` is not picklable and
-    crashes HTTPS action-server startup
-    (``TypeError: cannot pickle 'SSLContext' object``). Sanic only rewrites the
-    value to a picklable cert/key dict when it is already a ``SanicSSLContext``.
+    A live ``ssl.SSLContext`` is not picklable and crashes HTTPS action-server
+    startup (``TypeError: cannot pickle 'SSLContext' object``). Sanic only
+    rewrites the value to a picklable cert/key dict when it is already a
+    ``SanicSSLContext``, which requires passing cert/key paths to ``prepare()``.
     """
     assert _SSL_CERT.is_file(), f"missing test cert: {_SSL_CERT}"
     assert _SSL_KEY.is_file(), f"missing test key: {_SSL_KEY}"

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -1,9 +1,11 @@
-from typing import Any, Dict, List, Text
+from typing import Any, Dict, List, Optional, Text
 import json
 import logging
+import pickle
 import zlib
 
 import pytest
+from pytest import MonkeyPatch
 from sanic import Sanic
 
 import rasa_sdk.endpoint as ep
@@ -174,3 +176,36 @@ def test_server_webhook_custom_action_with_dialogue_stack_returns_200(
 
     assert events == [SlotSet("stack", dialogue_stack)]
     assert response.status == 200
+
+
+def test_run_app_loader_factory_is_picklable(
+    monkeypatch: MonkeyPatch,
+    action_executor: ep.ActionExecutor,
+) -> None:
+    """Sanic.serve pickles AppLoader when spawning workers.
+
+    Nested factories defined inside ``run()`` are not picklable and crash
+    action-server startup (``Can't pickle local object 'run.<locals>._app_factory'``).
+    """
+    captured: Dict[Text, Any] = {}
+
+    def fake_serve(
+        *,
+        primary: Optional[Sanic] = None,
+        app_loader: Any = None,
+        **_kwargs: Any,
+    ) -> None:
+        captured["app_loader"] = app_loader
+
+    monkeypatch.setattr(ep.Sanic, "serve", fake_serve)
+
+    ep.run(action_executor, port=5099)
+
+    app_loader = captured.get("app_loader")
+    assert app_loader is not None
+    assert app_loader.factory is not None
+
+    # Round-trip through pickle the same way Sanic's multiprocess manager does.
+    restored_loader = pickle.loads(pickle.dumps(app_loader))
+    restored_app = restored_loader.load()
+    assert restored_app.name == "rasa_sdk"

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -3,10 +3,12 @@ import json
 import logging
 import pickle
 import zlib
+from pathlib import Path
 
 import pytest
 from pytest import MonkeyPatch
 from sanic import Sanic
+from sanic.http.tls.context import SanicSSLContext
 
 import rasa_sdk.endpoint as ep
 from rasa_sdk.events import SlotSet
@@ -14,6 +16,34 @@ from tests.conftest import get_stack
 
 
 logger = logging.getLogger(__name__)
+
+# Shared by gRPC TLS integration tests; reused here for HTTPS startup pickling.
+_SSL_CERT = Path("integration_tests/grpc_server/setup/certs/server.pem")
+_SSL_KEY = Path("integration_tests/grpc_server/setup/certs/server-key.pem")
+
+
+def _capture_sanic_serve(monkeypatch: MonkeyPatch) -> Dict[Text, Any]:
+    """Stub ``Sanic.serve`` and return a dict of captured kwargs."""
+    captured: Dict[Text, Any] = {}
+
+    def fake_serve(
+        *,
+        primary: Optional[Sanic] = None,
+        app_loader: Any = None,
+        **_kwargs: Any,
+    ) -> None:
+        captured["primary"] = primary
+        captured["app_loader"] = app_loader
+
+    monkeypatch.setattr(ep.Sanic, "serve", fake_serve)
+    return captured
+
+
+def _ssl_payload_sanic_would_pickle(ssl_config: Any) -> Any:
+    """Apply the same SSL rewrite Sanic.serve does before spawning workers."""
+    if isinstance(ssl_config, SanicSSLContext):
+        return ssl_config.sanic
+    return ssl_config
 
 
 @pytest.fixture
@@ -187,17 +217,7 @@ def test_run_app_loader_factory_is_picklable(
     Nested factories defined inside ``run()`` are not picklable and crash
     action-server startup (``Can't pickle local object 'run.<locals>._app_factory'``).
     """
-    captured: Dict[Text, Any] = {}
-
-    def fake_serve(
-        *,
-        primary: Optional[Sanic] = None,
-        app_loader: Any = None,
-        **_kwargs: Any,
-    ) -> None:
-        captured["app_loader"] = app_loader
-
-    monkeypatch.setattr(ep.Sanic, "serve", fake_serve)
+    captured = _capture_sanic_serve(monkeypatch)
 
     ep.run(action_executor, port=5099)
 
@@ -209,3 +229,34 @@ def test_run_app_loader_factory_is_picklable(
     restored_loader = pickle.loads(pickle.dumps(app_loader))
     restored_app = restored_loader.load()
     assert restored_app.name == "rasa_sdk"
+
+
+def test_run_ssl_config_is_picklable(
+    monkeypatch: MonkeyPatch,
+    action_executor: ep.ActionExecutor,
+) -> None:
+    """Sanic.serve pickles server SSL settings when spawning workers.
+
+    A live ``ssl.SSLContext`` from ``create_ssl_context()`` is not picklable and
+    crashes HTTPS action-server startup
+    (``TypeError: cannot pickle 'SSLContext' object``). Sanic only rewrites the
+    value to a picklable cert/key dict when it is already a ``SanicSSLContext``.
+    """
+    assert _SSL_CERT.is_file(), f"missing test cert: {_SSL_CERT}"
+    assert _SSL_KEY.is_file(), f"missing test key: {_SSL_KEY}"
+
+    captured = _capture_sanic_serve(monkeypatch)
+
+    ep.run(
+        action_executor,
+        port=5099,
+        ssl_certificate=str(_SSL_CERT),
+        ssl_keyfile=str(_SSL_KEY),
+    )
+
+    primary = captured.get("primary")
+    assert primary is not None
+    assert primary.state.ssl is not None
+
+    ssl_payload = _ssl_payload_sanic_would_pickle(primary.state.ssl)
+    pickle.loads(pickle.dumps(ssl_payload))


### PR DESCRIPTION
**Proposed changes**:

Fixes action-server container exit on startup after #1361 (`Sanic.serve` without `legacy=True`). Sanic pickles the app factory and SSL settings when spawning workers; both held unpicklable objects.

- Nesting `run.<locals>._app_factory` → module-level factory bound with `functools.partial`
- Live `ssl.SSLContext` → cert/key paths so each worker rebuilds its own context
- `ActionExecutor.__getstate__` drops unpicklable module objects from `_modules`

Regression tests cover both pickle failures from the CI logs ([job](https://github.com/RasaHQ/rasa-private/actions/runs/31702017318/job/94453700294)).

**How tested**:
- `pytest tests/` — 245 passed (includes the two new pickle regression tests)
- `ruff format` / `ruff check` / `mypy` clean on touched files

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [x] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [x] reformat files using `ruff` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)