### PR TITLE
prepared release of version 3.19.0.dev2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rasa-sdk"
-version = "3.17.0rc1"
+version = "3.19.0.dev2"
 description = "Open source machine learning framework to automate text- and voice-based conversations: NLU, dialogue management, connect to Slack, Facebook, and more - Create chatbots and voice assistants"
 authors = [ "Rasa Technologies GmbH <hi@rasa.com>",]
 maintainers = [ "Tom Bocklisch <tom@rasa.com>",]
@@ -72,8 +72,6 @@ exclude = [ "rasa_sdk/grpc_py", "eggs", ".git", ".pytest_cache", "build", "dist"
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
 coloredlogs = ">=10,<16"
-# Sanic 22.x/23.x HTTP is broken on CPython 3.14 (missing http.lifecycle
-# signals). 25.12 is the current LTS and officially supports Python 3.14.
 sanic = "~25.12"
 typing-extensions = "~4.15.0"
 Sanic-Cors = "^2.0.0"
@@ -87,12 +85,6 @@ opentelemetry-exporter-otlp = "~1.33.0"
 opentelemetry-api = "~1.33.0"
 grpcio = "~1.80.0"
 protobuf = "~5.29.5"
-# grpcio-tools is codegen-only (used by `make generate-grpc`, not imported at
-# runtime). It has no cp314 wheels below 1.75.1, and 1.75.1+ require protobuf 6.x
-# (incompatible with our protobuf ~5.29.5). Restrict it to <3.14 so runtime installs
-# on 3.14; gRPC code generation runs on the 3.11 quality job. Lifting this needs the
-# protobuf 5.x -> 6.x migration (see PR follow-ups).
-grpcio-tools = { version = "~1.66.2", python = "<3.14" }
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"
@@ -105,6 +97,10 @@ select = [ "D", "E", "F", "W", "RUF",]
 python_functions = "test_"
 asyncio_mode = "auto"
 
+[tool.poetry.dependencies.grpcio-tools]
+version = "~1.66.2"
+python = "<3.14"
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
@@ -115,14 +111,13 @@ pytest = "^7.4.0"
 questionary = ">=1.5.1,<2.1.0"
 towncrier = "~25.8.0"
 toml = "^0.10.0"
-# pep440-version-utils has no release supporting Python 3.14 (1.2.0 caps <3.14).
-# It is only used by the release scripts (scripts/release.py,
-# scripts/publish_gh_release_notes.py), which run on the pinned release Python,
-# so it is restricted to <3.14 rather than blocking the 3.14 lock. See PR follow-ups.
-pep440-version-utils = { version = "~1.2.0", python = "<3.14" }
 semantic_version = "^2.8.5"
 mypy = "~2.1.0"
 sanic-testing = "~24.6.0"
 ruff = "~0.15.14"
 pytest-asyncio = "^0.23.6"
 types-protobuf = "4.25.0.20240417"
+
+[tool.poetry.group.dev.dependencies.pep440-version-utils]
+version = "~1.2.0"
+python = "<3.14"

--- a/rasa_sdk/version.py
+++ b/rasa_sdk/version.py
@@ -1,3 +1,3 @@
 # this file will automatically be changed,
 # do not add anything but the version number here!
-__version__ = "3.17.0rc1"
+__version__ = "3.19.0.dev2"


### PR DESCRIPTION
**Proposed changes**:

## Summary
Dev release of `rasa-sdk` **3.19.0.dev2** from `main`.

Carries Python 3.14 support landed in #1361 (`requires-python = ">=3.10,<3.15"`), so Rasa Pro (ENG-3128) can drop its interim git dependency and pin a published version.

## Changes
Version bump only (`rasa_sdk/version.py`, `pyproject.toml`): `3.17.0rc1` → `3.19.0.dev2`  

## After merge
- [ ] Tag created (`3.19.0.dev2`)
- [ ] [Release artifacts](https://github.com/RasaHQ/rasa-sdk/actions/workflows/release-artifacts.yml) green
- [ ] Package visible on PyPI: https://pypi.org/project/rasa-sdk/3.19.0.dev2/

Refs: ENG-3127, ENG-3128

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation in the [rasaHQ/rasa](https://github.com/rasaHQ/rasa)
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa-sdk/tree/main/changelog) for instructions)
- [ ] reformat files using `ruff` (please check [Readme](https://github.com/RasaHQ/rasa-sdk#code-style) for instructions)
