### PR TITLE
PF-1465: use rangeStrategy `replace`, not `pin`, for the SDK

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -54,6 +54,15 @@
     },
   ],
   labels: ["type:dependencies"],
-  rangeStrategy: "pin",
+  // `replace` rather than `pin`: rasa-sdk is a published library, so the
+  // constraints in pyproject.toml become Requires-Dist on PyPI and are resolved
+  // in the customer's environment alongside rasa-private. Pinning them to `==`
+  // would hand customers unsatisfiable co-installs. `replace` edits a constraint
+  // only when the new version falls outside it, which is what Dependabot did
+  // here historically (e.g. mypy "^0.910" -> "^0.950"); in-range bumps move
+  // poetry.lock alone, so CI stays reproducible without narrowing what we ship.
+  // Deployed services (studio, rasa-pro-services) can keep `pin` -- nothing
+  // consumes their constraints.
+  rangeStrategy: "replace",
   semanticCommits: "disabled",
 }


### PR DESCRIPTION
**Ticket**: [PF-1465](https://rasahq.atlassian.net/browse/PF-1465) (epic [PF-1454](https://rasahq.atlassian.net/browse/PF-1454)) — unblocks #1395

Changes `rangeStrategy` from `pin` to `replace` for this repo only.

## Why

rasa-sdk is a published library. The constraints in `pyproject.toml` become `Requires-Dist` in the wheel — 3.18.0 ships `Sanic-Cors<3.0.0,>=2.0.0`, `coloredlogs<16,>=10` — and get resolved in the customer's environment alongside `rasa-private`. `pin` rewrites those as exact `==`, so a customer installing both can hit an unsatisfiable resolve.

This isn't theoretical: the dashboard has a **`Pin dependencies (main)`** PR queued covering all 24 ranged deps, and 6 of the 9 in `Update all poetry dependencies (main)` are runtime deps that ship — `grpcio`, `grpcio-health-checking`, `grpcio-tools`, `opentelemetry-api`/`-sdk`/`-exporter-otlp`, `typing-extensions`.

Same reasoning rasa-private's Dependabot config recorded for its pip block:

> we enforce `increase` here because it ensures that we maintain a small range of compatible versions; it speeds up installation with pip for our customers

`pin` stays correct for `studio` and `rasa-pro-services` — deployed services, nothing consumes their constraints. This is a library-vs-application distinction, not a mistake in the shared pattern.

## Why `replace` specifically

It matches what Dependabot actually did in this repo — I checked the history rather than guessing:

| dep | before | after |
|---|---|---|
| `mypy` | `^0.910` | `^0.950` |
| `flake8` | `^3.8.3` | `^4.0.1` |
| `pytest-cov` | `^2.10.0` | `^3.0.0` |
| `sanic-testing` | `^0.8.0` | `^22.3.0` |

Ranges kept, bounds raised, nothing pinned.

`replace` edits a constraint only when the new version falls outside it. In-range bumps move `poetry.lock` alone (it's tracked), so CI stays reproducible without narrowing what we publish. I chose it over `bump` because `bump` raises the floor even when the new version already satisfies the range — on `~1.33.0` that ratchets the customer's minimum on every patch, for no benefit.

## How to verify

The five queued `Pin dependencies` entries should disappear from [dashboard #1387](https://github.com/RasaHQ/rasa-sdk/issues/1387) once this lands. That's the check.

Then tick `Update all poetry dependencies (main)` and confirm the diff keeps ranges — after which #1395 can be undrafted.

## Two things I did not change

- **`automerge: true` on the `all-poetry` group.** Ticking that dashboard box opens a PR that merges itself once CI is green. Fine once `rangeStrategy` is right, but worth a deliberate decision — I couldn't read branch protection on `main` to see whether a required review would hold it.
- **`vulnerabilityAlerts` has no `rangeStrategy`**, so it inherits Renovate's default `update-lockfile` for security PRs. That means a security fix needing a version *outside* the declared range may not be actionable via the lockfile alone. Pre-existing, unaffected by this PR, but probably worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PF-1465]: https://rasahq.atlassian.net/browse/PF-1465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PF-1454]: https://rasahq.atlassian.net/browse/PF-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ